### PR TITLE
Solution to bug 1022

### DIFF
--- a/APP.Eds/APP.Eds/Components/PopUp/AddCourtExpenditure.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddCourtExpenditure.xaml.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+using APP.Eds.Models.Court;
 using APP.Eds.Services.Court;
 using CommunityToolkit.Maui.Views;
 
@@ -25,18 +27,29 @@ public partial class AddCourtExpenditure : Popup
         if (BindingContext is CourtService vm && vm.SelectedExpenditure is not null)
         {
             var selectedExpenditure = vm.SelectedExpenditure.IdCourtExpenditure;
-            await courtService.AddCourtExpenditureFromPopup();
+            
         }
         else
         {
             await Application.Current.MainPage.DisplayAlert("Error", "Por favor, seleccione un tipo de Egreso", "OK");
         }
+        if (courtService.CourtExpenditureAmount <= 0)
+        {
+            await Application.Current.MainPage.DisplayAlert("Error", "Por favor, el egreso debe ser mayor a 0", "OK");
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(courtService.ExpenditureDescription))
+        {
+            await Application.Current.MainPage.DisplayAlert("Error", "Por favor, Ingrese una descripcion", "OK");
+            return;
+        }
+        await courtService.AddCourtExpenditureFromPopup();
 
         ExpenditurePicker.SelectedItem = null;
         FirstEntry.IsEnabled = false;
         SecondEntry.IsEnabled = false;
 
-        Close();
+        //Close();
     }
 
     private void ExpenditureSelected(object sender, EventArgs e)
@@ -48,14 +61,21 @@ public partial class AddCourtExpenditure : Popup
             FirstEntry.Focus();
             FirstEntry.CursorPosition = FirstEntry.Text.Length;
         }
+        
     }
 
-    private void EntryAmountCompleted(object sender, EventArgs e)
+    private async void EntryAmountCompleted(object sender, EventArgs e)
     {
-        if (BindingContext is CourtService vm)
+        if (BindingContext is CourtService)
         {
-            SecondEntry.Focus();
+            if (courtService.CourtExpenditureAmount <= 0)
+            {
+                await Application.Current.MainPage.DisplayAlert("Error", "Por favor, el egreso debe ser mayor a 0", "OK");
+                return;
+            }
+            
         }
+        
     }
 
     private void EntryDescriptionCompleted(object sender, EventArgs e)

--- a/APP.Eds/APP.Eds/Components/PopUp/AddCourtTypeOfCollection.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddCourtTypeOfCollection.xaml.cs
@@ -25,18 +25,29 @@ public partial class AddCourtTypeOfCollection : Popup
         if (BindingContext is CourtService vm && vm.SelectedTypeOfCollection is not null)
         {
             var selectedExpenditure = vm.SelectedTypeOfCollection.IdTypeOfCollection;
-            await courtService.AddCourtTypeOfCollectionFromPopup();
+            
         }
         else
         {
             await Application.Current.MainPage.DisplayAlert("Error", "Por favor, seleccione un Tipo de Recaudo", "OK");
         }
+        if (courtService.CourtTypeOfCollectionAmount <= 0)
+        {
+            await Application.Current.MainPage.DisplayAlert("Error", "Por favor, el egreso debe ser mayor a 0", "OK");
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(courtService.CourtTypeOfCollectionDescription))
+        {
+            await Application.Current.MainPage.DisplayAlert("Error", "Por favor, ingrese una descripcion", "OK");
+            return;
+        }
+        await courtService.AddCourtTypeOfCollectionFromPopup();
 
         TypeOfCollentionPicker.SelectedItem = null;
         FirstEntry.IsEnabled = false;
         SecondEntry.IsEnabled = false;
 
-        Close();
+        //Close();
     }
 
     private void TypeOfCollentionSelected(object sender, EventArgs e)
@@ -65,22 +76,33 @@ public partial class AddCourtTypeOfCollection : Popup
                 entry.Text = e.OldTextValue;
             }
         }
-    }   
-    private void EntryAmountCompleted(object sender, EventArgs e)
+    }
+    private async void EntryAmountCompleted(object sender, EventArgs e)
     {
-        if (BindingContext is CourtService vm)
+        if (BindingContext is CourtService)
         {
+            if (courtService.CourtTypeOfCollectionAmount <= 0)
+            {
+                await Application.Current.MainPage.DisplayAlert("Error", "Por favor, el egreso debe ser mayor a 0", "OK");
+                return;
+
+            }
             SecondEntry.Focus();
         }
     }
     
     
-    private void EntryDescriptionCompleted(object sender, EventArgs e)
+    private async void EntryDescriptionCompleted(object sender, EventArgs e)
     {
-        if (BindingContext is CourtService vm)
+        if (BindingContext is CourtService)
         {
-            AddButton.Focus();
+            if (string.IsNullOrWhiteSpace(courtService.CourtTypeOfCollectionDescription))
+            {
+                await Application.Current.MainPage.DisplayAlert("Error", "Por favor, ingrese una descripcion", "OK");
+                return;
+            }  
         }
+        AddButton.Focus();
     }
 
 


### PR DESCRIPTION
## Summary by Sourcery

Implement input validation in the court collection and expenditure popups to ensure positive amounts and non-empty descriptions before allowing submission, convert related event handlers to async for alert display, and disable automatic popup closing after submission.

Bug Fixes:
- Prevent submission of zero or negative amounts in both collection and expenditure popups
- Block adding entries when the description is empty and show corresponding error alerts

Enhancements:
- Convert entry completion handlers to async to perform inline validation with alerts
- Comment out automatic popup Close call to keep the dialog open after validation failures

Chores:
- Add necessary using directives for System.Threading.Tasks and court models