### PR TITLE
GallonsAutomaticCalcullated

### DIFF
--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
@@ -116,14 +116,21 @@
                                                TextColor="Black"
                                                Keyboard="Numeric"
                                                Placeholder="Ingrese los galones"
-                                               Text="{Binding AccumulatedGallons, Mode=TwoWay, StringFormat='{0:N0}'}"
+                                               Text="{Binding AccumulatedGallons, Mode=TwoWay, StringFormat='{0:N2}'}"
                                                Margin="2"
                                                Unfocused="OnEntryUnfocused"
                                                Completed="EntryGallonsCompleted"
-                                    TextChanged="FirstEntry_TextChanged"
+                                               TextChanged="FirstEntry_TextChanged"
                                                IsEnabled="False"/>
                                     </Grid>
+                                    <Button Text="✎"
+                                            Clicked="EditGallonsButton_Clicked"
+                                            BackgroundColor="Transparent"
+                                            WidthRequest="30"
+                                            HeightRequest="30"
+                                            VerticalOptions="Center"/>
                                 </HorizontalStackLayout>
+
                                 <Label Text="{Binding GallonsDifferenceResult, StringFormat='Gallons: {0:N0}'}" VerticalOptions="Center" HorizontalOptions="Center" TextColor="Black"/>
                             </VerticalStackLayout>
                         </HorizontalStackLayout>

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
@@ -89,7 +89,7 @@
                                                Margin="2"
                                                Unfocused="OnEntryUnfocused"
                                                Completed="EntryAccumulatedCompleted"
-                                    TextChanged="FirstEntry_TextChanged"
+                                               TextChanged="FirstEntry_TextChanged"
                                                IsEnabled="False"/>
                                     </Grid>
                                 </HorizontalStackLayout>

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
@@ -6,7 +6,7 @@
 	xmlns:mct="clr-namespace:CommunityToolkit.Maui.Views;assembly=CommunityToolkit.Maui"
 	CanBeDismissedByTappingOutsideOfPopup="False"
     Color="Transparent">
-    
+
     <Frame
 		Padding="20"
 		BackgroundColor="White"
@@ -43,7 +43,7 @@
                         HorizontalOptions="End"
                         VerticalOptions="Center"/>
             </Grid>
-            
+
             <!--  Campos de Entrada  -->
             <ScrollView Grid.Row="1" MaximumHeightRequest="500" Margin="0,0,0,10">
                 <VerticalStackLayout>
@@ -65,6 +65,13 @@
                                 TextColor="Black"/>
                         </HorizontalStackLayout>
                     </Frame>
+                    <Label
+                        x:Name="PricePerGallonLabel"
+                        Text="Precio por galón: -"
+                        FontAttributes="Bold"
+                        Margin="0,0,0,10"
+                        TextColor="Black"
+                        HorizontalOptions="Start" />
                     <Frame Padding="10"
                            BackgroundColor="#F5F5F5"
                            CornerRadius="10"
@@ -131,13 +138,13 @@
                                             VerticalOptions="Center"/>
                                 </HorizontalStackLayout>
 
-                                <Label Text="{Binding GallonsDifferenceResult, StringFormat='Gallons: {0:N0}'}" VerticalOptions="Center" HorizontalOptions="Center" TextColor="Black"/>
+                                <Label Text="{Binding GallonsDifferenceResult, StringFormat='Gallons: {0:N2}'}" VerticalOptions="Center" HorizontalOptions="Center" TextColor="Black"/>
                             </VerticalStackLayout>
                         </HorizontalStackLayout>
                     </Frame>
                 </VerticalStackLayout>
             </ScrollView>
-            
+
             <!--  Botón Agregar  -->
             <Button Grid.Row="2"
                     x:Name="AddButton"

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
@@ -84,19 +84,18 @@ public partial class AddDispenser : Popup
             await Application.Current.MainPage.DisplayAlert("Error", "Por favor, seleccione una Manguera", "OK");
         }
     }
-    private const double PricePerGallon = 5000.0;
+
     private void EntryAccumulatedCompleted(object sender, EventArgs e)
     {
         if (BindingContext is CourtService vm)
         {
             AmountBoxView.Color = vm.AccumulatedAmount >= vm.LastAccumulatedAmount ? Colors.Green : Colors.Red;
             GallonBoxView.Color = vm.AccumulatedGallons >= vm.LastAccumulatedGallons ? Colors.Green : Colors.Red;
-
-            // Cálculo automático de galones
+            
             if (vm.AccumulatedAmount > vm.LastAccumulatedAmount)
             {
                 double diferenciaMonto = vm.AccumulatedAmount - vm.LastAccumulatedAmount;
-                vm.AccumulatedGallons = vm.LastAccumulatedGallons + (diferenciaMonto / PricePerGallon);
+                vm.AccumulatedGallons = vm.LastAccumulatedGallons + (diferenciaMonto / vm.SelectedHose.Price);
             }
 
             SecondEntry.Focus();

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
@@ -94,8 +94,7 @@ public partial class AddDispenser : Popup
             
             if (vm.AccumulatedAmount > vm.LastAccumulatedAmount)
             {
-                double diferenciaMonto = vm.AccumulatedAmount - vm.LastAccumulatedAmount;
-                vm.AccumulatedGallons = vm.LastAccumulatedGallons + (diferenciaMonto / vm.SelectedHose.Price);
+                vm.AccumulatedGallons = vm.LastAccumulatedGallons + (vm.AmountDifferenceResult / vm.SelectedHose.Price);
             }
 
             SecondEntry.Focus();
@@ -121,14 +120,30 @@ public partial class AddDispenser : Popup
 
     private void HoseSelected(object sender, EventArgs e)
     {
-        if(HosePicker.SelectedIndex != -1)
+        if (HosePicker.SelectedIndex != -1)
         {
             FirstEntry.IsEnabled = true;
             SecondEntry.IsEnabled = true;
             FirstEntry.Focus();
             FirstEntry.CursorPosition = FirstEntry.Text.Length;
+
+            // Mostrar el precio directamente desde el modelo seleccionado
+            if (BindingContext is CourtService vm && vm.SelectedHose is not null)
+            {
+                double price = vm.SelectedHose.Price;
+                PricePerGallonLabel.Text = $"Precio por galón: {price:C2}";
+            }
+            else
+            {
+                PricePerGallonLabel.Text = "Precio por galón: -";
+            }
+        }
+        else
+        {
+            PricePerGallonLabel.Text = "Precio por galón: -";
         }
     }
+
     private void FirstEntry_TextChanged(object sender, TextChangedEventArgs e)
     {
         if (sender is Entry entry)

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
@@ -3,17 +3,28 @@ using CommunityToolkit.Maui.Views;
 
 namespace APP.Eds.Components.PopUp;
 
+
 public partial class AddDispenser : Popup
 {
     private readonly CourtService courtService;
+    private bool isGallonsEditable = false;
 
     public AddDispenser(CourtService courtService)
     {
         InitializeComponent();
         this.courtService = courtService;
-
+        SecondEntry.IsEnabled = isGallonsEditable;
     }
-
+    private void EditGallonsButton_Clicked(object sender, EventArgs e)
+    {
+        isGallonsEditable = !isGallonsEditable;
+        SecondEntry.IsEnabled = isGallonsEditable;
+        if (isGallonsEditable)
+        {
+            SecondEntry.Focus();
+            SecondEntry.CursorPosition = SecondEntry.Text?.Length ?? 0;
+        }
+    }
     private void OnCloseTapped(object sender, EventArgs e)
     {
         if (BindingContext is CourtService vm)
@@ -73,26 +84,31 @@ public partial class AddDispenser : Popup
             await Application.Current.MainPage.DisplayAlert("Error", "Por favor, seleccione una Manguera", "OK");
         }
     }
-    
-    private void OnEntryUnfocused(object sender, FocusEventArgs e)
-    {
-        if (BindingContext is CourtService vm)
-        {
-            AmountBoxView.Color = vm.AccumulatedAmount >= vm.LastAccumulatedAmount ? Colors.Green : Colors.Red;
-            GallonBoxView.Color = vm.AccumulatedGallons >= vm.LastAccumulatedGallons ? Colors.Green : Colors.Red;
-        }
-    }
+    private const double PricePerGallon = 5000.0;
     private void EntryAccumulatedCompleted(object sender, EventArgs e)
     {
         if (BindingContext is CourtService vm)
         {
             AmountBoxView.Color = vm.AccumulatedAmount >= vm.LastAccumulatedAmount ? Colors.Green : Colors.Red;
             GallonBoxView.Color = vm.AccumulatedGallons >= vm.LastAccumulatedGallons ? Colors.Green : Colors.Red;
+
+            // Cálculo automático de galones
+            if (vm.AccumulatedAmount > vm.LastAccumulatedAmount)
+            {
+                double diferenciaMonto = vm.AccumulatedAmount - vm.LastAccumulatedAmount;
+                vm.AccumulatedGallons = vm.LastAccumulatedGallons + (diferenciaMonto / PricePerGallon);
+            }
+
             SecondEntry.Focus();
             SecondEntry.CursorPosition = SecondEntry.Text.Length;
-
         }
     }
+   
+    private void OnEntryUnfocused(object sender, FocusEventArgs e)
+    {
+
+    }
+
 
     private void EntryGallonsCompleted(object sender, EventArgs e)
     {

--- a/APP.Eds/APP.Eds/Models/Court/HoseCourtModel.cs
+++ b/APP.Eds/APP.Eds/Models/Court/HoseCourtModel.cs
@@ -25,6 +25,9 @@ public class HoseCourtModel
     [JsonPropertyName("idProductType")]
     public int IdProductType { get; set; }
 
+    [JsonPropertyName("price")]
+    public double Price { get; set; }
+
     [JsonPropertyName("dispensersEntity")]
     public DispenserCourtModel DispensersEntity { get; set; }
 
@@ -33,6 +36,8 @@ public class HoseCourtModel
 
     [JsonPropertyName("edsEntity")]
     public EdsResponse EdsEntity { get; set; }
+
+   
 
     public string ProductName => ProductTypeEntity?.Description ?? "Unknown";
     public int DispensersNumber => DispensersEntity?.Number ?? 0;

--- a/APP.Eds/APP.Eds/Models/Hose/HoseModel.cs
+++ b/APP.Eds/APP.Eds/Models/Hose/HoseModel.cs
@@ -7,5 +7,6 @@
         public double AccumulatedAmount { get; set; }
         public double AccumulatedGallons { get; set; }
         public int IdProductType { get; set; } 
+        public double Price { get; set; }
     }
 }

--- a/APP.Eds/APP.Eds/Models/Hose/HoseResponse.cs
+++ b/APP.Eds/APP.Eds/Models/Hose/HoseResponse.cs
@@ -21,4 +21,7 @@ public class HoseResponse
 
     [JsonProperty("idProductType")]
     public int IdProductType { get; set; }
+
+    [JsonProperty("price")]
+    public double Price { get; set; }
 }


### PR DESCRIPTION
Automatic Gallons when amount is writed

## Summary by Sourcery

Implement auto-calculation of gallons from the entered amount and add a toggle for manual editing of the gallons field in the AddDispenser popup.

New Features:
- Automatically compute accumulated gallons when a new amount is entered using a fixed price per gallon.
- Introduce a toggle button to enable or disable manual editing of the gallons input.

Enhancements:
- Disable the gallons input field by default and shift focus to it after completing amount entry.
- Consolidate color feedback for amount and gallons into the amount entry completion handler.