### PR TITLE
Order hoses by dispenser number

### DIFF
--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -2390,16 +2390,23 @@ GetAllEdsData()
 
         public void LoadHoseByEds(int edsId)
         {
-            var filteredIsHoseByEds = HoseList.Where(x => x.EdsEntity.IdEds == edsId).ToList();
+            var filteredIsHoseByEds = HoseList
+                .Where(x => x.EdsEntity.IdEds == edsId)
+                .OrderBy(x => x.IdDispensers)
+                .ThenBy(x => x.Number) 
+                .ToList();
+
             HoseDispenserList.Clear();
-            foreach (var islander in filteredIsHoseByEds)
+            foreach (var hose in filteredIsHoseByEds)
             {
-                HoseDispenserList.Add(islander);
+                HoseDispenserList.Add(hose);
             }
             OnPropertyChanged(nameof(HoseDispenserList));
             OnPropertyChanged(nameof(AreAvailableHoses));
             OnPropertyChanged(nameof(NewSaleEnabled));
         }
+
+
 
         public void AddSelectedHose(HoseCourtModel hose)
         {


### PR DESCRIPTION
Order hoses by dispenser number

## Summary by Sourcery

Order the hoses loaded for a dispenser by their dispenser ID then by hose number

Enhancements:
- Sort hoses by dispenser ID and hose number in LoadHoseByEds
- Rename loop variable to 'hose' for improved clarity