### PR TITLE
OK Reset Code

### DIFF
--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -30,9 +30,24 @@ namespace APP.Eds.Services.Court
         public static CourtService Instance => _instance ??= new CourtService();
         private string? _authToken;
 
-        public static void ResetInstance()
+        public static void ResetInstanceFields()
         {
-            _instance = null;
+            _instance._authToken = null;
+            _instance.SelectedBusiness = null;
+            _instance.SelectedEds = null;
+            _instance.SelectedIslander = null;
+            _instance.TotalAmount = 0;
+            _instance.TotalGallons = 0;
+            _instance.TotalExpenditure = 0;
+            _instance.TotalTypeOfCollection = 0;
+            _instance.TotalSales = 0;
+            _instance.Distintic = 0;
+            _instance.CourtDispensers = null;
+            _instance.CourtDocuments = null;
+            _instance.CourtExpenditures = null;
+            _instance.CourtTypeOfCollections = null;
+            _instance.AdditionalInformation = null;
+            
         }
 
 

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
@@ -118,7 +118,7 @@ public partial class CourtPostView : ContentPage
 
                 var selectedId = vm.SelectedEds.IdEds;
                 await vm.SendCourtDataAsync();
-                CourtService.ResetInstance();
+                CourtService.ResetInstanceFields();
                 _service = CourtService.Instance;
                 BindingContext = _service;
 


### PR DESCRIPTION
## Summary by Sourcery

Replace the singleton reset logic in CourtService to clear its fields rather than nullifying the instance and update the view to use the new reset method.

Enhancements:
- Introduce ResetInstanceFields to reset CourtService properties instead of dropping the singleton instance
- Update CourtPostView to call ResetInstanceFields in place of ResetInstance