### PR TITLE
Hu-TranslationCategory

### DIFF
--- a/APP.Eds/APP.Eds/Services/Category/CategoryService.cs
+++ b/APP.Eds/APP.Eds/Services/Category/CategoryService.cs
@@ -52,6 +52,50 @@ namespace APP.Eds.Services.Category
                 }
             }
         }
+
+        private string _SendData = string.Empty;
+        public string SendData
+        {
+            get => _SendData;
+            set
+            {
+                if (_SendData != value)
+                {
+                    _SendData = value;
+                    OnPropertyChanged(nameof(SendData));
+                }
+            }
+        }
+
+        private string _EnterCategory = string.Empty;
+
+        public string EnterCategory
+        {
+            get => _EnterCategory;
+            set
+            {
+                if (_EnterCategory != value)
+                {
+                    _EnterCategory = value;
+                    OnPropertyChanged(nameof(EnterCategory));
+                }
+            }
+        }    
+
+        private string _CategoryManagement = string.Empty;
+
+        public string CategoryManagement
+        {
+            get => _CategoryManagement;
+            set
+            {
+                if (_CategoryManagement != value)
+                {
+                    _CategoryManagement = value;
+                    OnPropertyChanged(nameof(CategoryManagement));
+                }
+            }
+        }
         public  CategoryService()
         {
             _authToken = TokenHelper.LoadToken(Configuration.KeycloakCliendId, Configuration.KeycloakRealms);
@@ -64,6 +108,9 @@ namespace APP.Eds.Services.Category
             var result = await GetTranslationsByLanguageAsync("es-CO");
             GlobalTranslations.SetTranslations(result ?? []);
             CategoryTranslation = GlobalTranslations.Get("Category");
+            SendData = GlobalTranslations.Get("SendData");
+            EnterCategory = GlobalTranslations.Get("EnterCategory");
+            CategoryManagement = GlobalTranslations.Get("CategoryManagement");
 
         }
         public async Task<Dictionary<string, string>> GetTranslationsByLanguageAsync(string languageTag)

--- a/APP.Eds/APP.Eds/Services/Category/CategoryService.cs
+++ b/APP.Eds/APP.Eds/Services/Category/CategoryService.cs
@@ -38,8 +38,9 @@ namespace APP.Eds.Services.Category
         }
         public ICommand GetByIdCategoryDataCommand { get; }
         public ICommand SaveCategoryDataCommand { get; }
-        private string _CategoryTranslation = string.Empty;
 
+
+        private string _CategoryTranslation = string.Empty;
         public string CategoryTranslation
         {
             get => _CategoryTranslation;

--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -1509,7 +1509,37 @@ namespace APP.Eds.Services.Court
                     OnPropertyChanged(nameof(TypeofCollectionTranslation));
                 }
             }
-        }        
+        } 
+        
+        private string _CategoryTranslation = string.Empty;
+
+        public string CategoryTranslation
+        {
+            get => _CategoryTranslation;
+            set
+            {
+                if (_CategoryTranslation != value)
+                {
+                    _CategoryTranslation = value;
+                    OnPropertyChanged(nameof(CategoryTranslation));
+                }
+            }
+        }
+
+        private string _EnterCategory = string.Empty;
+
+        public string EnterCategory
+        {
+            get => _EnterCategory;
+            set
+            {
+                if (_EnterCategory != value)
+                {
+                    _EnterCategory = value;
+                    OnPropertyChanged(nameof(EnterCategory));
+                }
+            }
+        }
 
         private EdsCourtModel _selectedEds;
         public EdsCourtModel SelectedEds
@@ -1792,6 +1822,9 @@ namespace APP.Eds.Services.Court
                 TypeofCollectionTranslation = GlobalTranslations.Get("TypeofCollection");
                 LastAccumulatedGallonsTranslation = GlobalTranslations.Get("LastAccumulatedGallons");
                 LastAccumulatedAmountTranslation = GlobalTranslations.Get("LastAccumulatedAmount");
+                CategoryTranslation = GlobalTranslations.Get("Category");
+                EnterCategory = GlobalTranslations.Get("EnterCategory");
+        
             }
             catch (Exception ex)
             {

--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -1541,6 +1541,21 @@ namespace APP.Eds.Services.Court
             }
         }
 
+        private string _CategoryManagement = string.Empty;
+
+        public string CategoryManagement
+        {
+            get => _CategoryManagement;
+            set
+            {
+                if (_CategoryManagement != value)
+                {
+                    _CategoryManagement = value;
+                    OnPropertyChanged(nameof(CategoryManagement));
+                }
+            }
+        }
+
         private EdsCourtModel _selectedEds;
         public EdsCourtModel SelectedEds
         {
@@ -1822,9 +1837,7 @@ namespace APP.Eds.Services.Court
                 TypeofCollectionTranslation = GlobalTranslations.Get("TypeofCollection");
                 LastAccumulatedGallonsTranslation = GlobalTranslations.Get("LastAccumulatedGallons");
                 LastAccumulatedAmountTranslation = GlobalTranslations.Get("LastAccumulatedAmount");
-                CategoryTranslation = GlobalTranslations.Get("Category");
-                EnterCategory = GlobalTranslations.Get("EnterCategory");
-        
+
             }
             catch (Exception ex)
             {

--- a/APP.Eds/APP.Eds/UsesCases/Category/CategoryPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Category/CategoryPostView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="APP.Eds.UsesCases.Category.CategoryPostView"
              xmlns:controls="clr-namespace:APP.Eds.UsesCases.LoadingView"
-             Title="Gestión Categoria">
+             Title="{Binding CategoryManagement}"> 
     <AbsoluteLayout>
         <VerticalStackLayout
         AbsoluteLayout.LayoutBounds="0,0,1,1"
@@ -20,11 +20,11 @@
             BackgroundColor="Green"
             Clicked="Button_Clicked_1"
             CornerRadius="10"
-            Text="Send Data"
+            Text="{Binding SendData, Mode=TwoWay}"
             TextColor="White" />
         </VerticalStackLayout>
         <controls:LoadingView x:Name="LoadingOverlay"
                           AbsoluteLayout.LayoutBounds="0,0,1,1"
                           AbsoluteLayout.LayoutFlags="All"/>
     </AbsoluteLayout>
-</ContentPage>
+</ContentPage>    

--- a/APP.Eds/APP.Eds/UsesCases/Category/CategoryPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Category/CategoryPostView.xaml
@@ -3,24 +3,24 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="APP.Eds.UsesCases.Category.CategoryPostView"
              xmlns:controls="clr-namespace:APP.Eds.UsesCases.LoadingView"
-             Title="Gestión Categoría">
+             Title="Gestión Categoria">
     <AbsoluteLayout>
         <VerticalStackLayout
         AbsoluteLayout.LayoutBounds="0,0,1,1"
         AbsoluteLayout.LayoutFlags="All"
         Padding="20" Spacing="15">
-            <Label FontSize="16" Text="Categoría"/>
+            <Label FontSize="16" Text="{Binding CategoryTranslation, Mode=TwoWay}"/>
             <Entry
             x:Name="CategoryEntry"
             Keyboard="Text"
-            Placeholder="Ingresar la categoría"
+            Placeholder="{Binding EnterCategory, Mode=TwoWay}"
             Text="{Binding Description, Mode=TwoWay}"
             TextChanged="CategoryEntry_TextChanged"/>
             <Button
             BackgroundColor="Green"
             Clicked="Button_Clicked_1"
             CornerRadius="10"
-            Text="Enviar Datos"
+            Text="Send Data"
             TextColor="White" />
         </VerticalStackLayout>
         <controls:LoadingView x:Name="LoadingOverlay"

--- a/APP.Eds/APP.Eds/UsesCases/Category/CategoryPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Category/CategoryPostView.xaml.cs
@@ -52,4 +52,5 @@ public partial class CategoryPostView : ContentPage
             OnPropertyChanged();
         }
     }
+
 }


### PR DESCRIPTION
## Summary by Sourcery

Add multilingual support for categories by fetching translations from the API and exposing new UI-bound translation properties in service classes

Enhancements:
- Fetch and apply category-related translations in CategoryService via LoadTranslationsAsync and GetTranslationsByLanguageAsync
- Expose CategoryTranslation, SendData, EnterCategory, and CategoryManagement properties in CategoryService
- Add CategoryTranslation, EnterCategory, and CategoryManagement translation properties to CourtService

Chores:
- Reorder and clean up using directives
- Apply minor XAML code cleanup in CategoryPostView