### PR TITLE
Hu 1103 reset

### DIFF
--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -74,21 +74,6 @@ namespace APP.Eds.Services.Court
         private List<HoseCourtModel> selectedHoses = new List<HoseCourtModel>();
 
 
-        public string? AuthToken
-{
-    get => _authToken;
-    set
-    {
-        if (_authToken != value)
-        {
-            _authToken = value;
-            Preferences.Set("AuthToken", value);
-            OnPropertyChanged(nameof(AuthToken));
-        }
-    }
-}
-
-
         private CourtModel _court;
         public CourtModel Court
         {

--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -25,7 +25,8 @@ namespace APP.Eds.Services.Court
     public class CourtService : INotifyPropertyChanged
 
     {
-        
+        public bool LastSendWasSuccessful { get; private set; }
+
         private static CourtService _instance;
         public static CourtService Instance => _instance ??= new CourtService();
         private string? _authToken;
@@ -71,6 +72,21 @@ namespace APP.Eds.Services.Court
         public bool AdditionalInfoEnabled => !string.IsNullOrEmpty(AdditionalInfoDescription);
 
         private List<HoseCourtModel> selectedHoses = new List<HoseCourtModel>();
+
+
+        public string? AuthToken
+{
+    get => _authToken;
+    set
+    {
+        if (_authToken != value)
+        {
+            _authToken = value;
+            Preferences.Set("AuthToken", value);
+            OnPropertyChanged(nameof(AuthToken));
+        }
+    }
+}
 
 
         private CourtModel _court;
@@ -2382,6 +2398,8 @@ GetAllEdsData()
 
                 if (response.IsSuccessStatusCode)
                 {
+                    LastSendWasSuccessful = true;
+
                     if (CourtDocuments?.Any() == true)
                     {
                         string apiUrl = $"{Configuration.BaseUrl}/api/v1/files/upload";
@@ -2408,6 +2426,8 @@ GetAllEdsData()
                             }
                             catch (Exception ex)
                             {
+                                LastSendWasSuccessful = false;
+
                                 Console.WriteLine($"Error subiendo {doc.DocumentName}: {ex.Message}");
                             }
                         }
@@ -2417,12 +2437,17 @@ GetAllEdsData()
                 }
                 else
                 {
+                    LastSendWasSuccessful = false;
+
                     var error = await response.Content.ReadAsStringAsync();
                     await Application.Current.MainPage.DisplayAlert("Error", $"No se pudo enviar el dato: {response.StatusCode}\n{error}", "OK");
                 }
             }
             catch (Exception ex)
             {
+
+                LastSendWasSuccessful = false;
+
                 await Application.Current.MainPage.DisplayAlert("Error", $"Error al enviar los datos: {ex.Message}", "OK");
             }
         }

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
@@ -114,13 +114,19 @@ public partial class CourtPostView : ContentPage
             }
 
             var selectedId = vm.SelectedEds.IdEds;
+
             await vm.SendCourtDataAsync();
-            CourtService.ResetInstanceFields();
-            _service = CourtService.Instance;
-            BindingContext = _service;
+
+            if (vm.LastSendWasSuccessful)
+            {
+                CourtService.ResetInstanceFields();
+                _service = CourtService.Instance;
+                BindingContext = _service;
+            }
 
         }
     }
+
 
 
     private void OnBusinessSelected(object sender, EventArgs e)


### PR DESCRIPTION
OK Reset

## Summary by Sourcery

Add a success flag to CourtService and use it in the UI to conditionally reset state only after a successful send

New Features:
- Introduce LastSendWasSuccessful flag to CourtService to record the outcome of SendCourtDataAsync operations

Enhancements:
- Set LastSendWasSuccessful appropriately on HTTP success, failures, and exceptions
- Update CourtPostView to reset the CourtService instance only when the last send was successful