### PR TITLE
Duplicated code fixed APP.Eds.csproj

### DIFF
--- a/APP.Eds/APP.Eds/APP.Eds.csproj
+++ b/APP.Eds/APP.Eds/APP.Eds.csproj
@@ -98,7 +98,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />


### PR DESCRIPTION
Linea duplicada eliminada: <PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" />

## Summary by Sourcery

Chores:
- Remove redundant <PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" /> entry from APP.Eds.csproj