### PR TITLE
Court corrections

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+      - name: Install .NET MAUI Android workload
+        run: dotnet workload install maui-android
 
       - name: Install Android dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '8.0.x'
+          
       - name: Install .NET MAUI Android workload
         run: dotnet workload install maui-android
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build_android:
-    if: github.event.pull_request.merged == true
+    # if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
.NET MAUI Android workload Installed before "Install Android dependencies"

## Summary by Sourcery

Allow the Android build to run on any workflow trigger by disabling the merged PR check and add a step to install the .NET MAUI Android workload before installing other Android dependencies

CI:
- Comment out the `if: github.event.pull_request.merged == true` condition on the Android build job
- Add a `.NET MAUI Android workload` installation step prior to installing Android dependencies