### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           echo "$HOME/Android/Sdk/platform-tools" >> $GITHUB_PATH
 
       - name: Restore NuGet packages
-        run: dotnet restore APP.Eds/APP.Eds/APP.Eds.csproj
+        run: dotnet restore APP.Eds/APP.Eds/APP.Eds.csproj -p:TargetFramework=net8.0-android
 
       - name: Build Android project
         run: |


### PR DESCRIPTION
Dotnet restore must ignore IOS

## Summary by Sourcery

CI:
- Add -p:TargetFramework=net8.0-android flag to the dotnet restore step to ignore iOS