### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,9 @@ jobs:
       - name: Build Android project
         run: |
           dotnet publish APP.Eds/APP.Eds/APP.Eds.csproj \
-            -f:net8.0-android \
             -c:Release \
+            -f:net8.0-android \
+            -p:TargetFramework=net8.0-android \
             -o:./output
 
       - name: Find APK


### PR DESCRIPTION
Dotnet must ignore IOS

## Summary by Sourcery

CI:
- Adjust the dotnet publish command to include `-p:TargetFramework=net8.0-android` after the Release configuration