### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,15 +42,14 @@ jobs:
           echo "$HOME/Android/Sdk/platform-tools" >> $GITHUB_PATH
 
       - name: Restore NuGet packages
-        run: dotnet restore APP.Eds/APP.Eds/APP.Eds.csproj -p:TargetFramework=net8.0-android
+        run: dotnet restore APP.Eds/APP.Eds/APP.Eds.csproj -f net8.0-android
 
       - name: Build Android project
         run: |
           dotnet publish APP.Eds/APP.Eds/APP.Eds.csproj \
-            -c:Release \
-            -f:net8.0-android \
-            -p:TargetFramework=net8.0-android \
-            -o:./output
+            -c Release \
+            -f net8.0-android \
+            -o ./output
 
       - name: Find APK
         id: locate_apk


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions workflow to use consistent dotnet CLI flag syntax in restore and publish steps.

CI:
- Replace `-p:TargetFramework=net8.0-android` with `-f net8.0-android` in the restore step
- Switch `dotnet publish` flags to short-form syntax (e.g., `-c Release`, `-f net8.0-android`, `-o ./output`)