### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ jobs:
         with:
           dotnet-version: '8.0.x'
           
-      - name: Install .NET MAUI Android workload
-        run: dotnet workload install maui-android
+      - name: Install full .NET MAUI workload
+        run: dotnet workload install maui
 
       - name: Install Android dependencies
         run: |
@@ -49,9 +49,9 @@ jobs:
           dotnet publish APP.Eds/APP.Eds/APP.Eds.csproj \
             -c Release \
             -f net8.0-android \
-            -p:TargetFramework=net8.0-android \
-            -p:UseMaui=true \
-            -p:EnableWorkloadResolver=true \
+            -p TargetFramework=net8.0-android \
+            -p UseMaui=true \
+            -p EnableWorkloadResolver=true \
             -o ./output
 
       - name: Find APK


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions workflow to install the full .NET MAUI workload and standardize MSBuild property syntax in the dotnet publish step.

CI:
- Install the full MAUI workload by replacing `dotnet workload install maui-android` with `dotnet workload install maui`.
- Adjust MSBuild property flags in `dotnet publish` to use space-separated `-p` syntax for TargetFramework, UseMaui, and EnableWorkloadResolver.