### PR TITLE
Court corrections

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build_android:
-    # if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,9 +49,7 @@ jobs:
           dotnet publish APP.Eds/APP.Eds/APP.Eds.csproj \
             -c Release \
             -f net8.0-android \
-            -p TargetFramework=net8.0-android \
-            -p UseMaui=true \
-            -p EnableWorkloadResolver=true \
+            -p:TargetFramework=net8.0-android \
             -o ./output
 
       - name: Find APK


### PR DESCRIPTION
## Summary by Sourcery

Enforce the merge-based trigger for the Android build job and streamline the dotnet publish step in the GitHub Actions workflow

CI:
- Uncomment and activate the merge condition for the Android build job
- Use the colon syntax for TargetFramework and remove the UseMaui and EnableWorkloadResolver flags from the publish step