### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,11 +46,12 @@ jobs:
 
       - name: Build Android project
         run: |
-          dotnet publish APP.Eds/APP.Eds/APP.Eds.csproj \
+          dotnet build APP.Eds/APP.Eds/APP.Eds.csproj \
             -c Release \
             -f net8.0-android \
             -p:TargetFramework=net8.0-android \
-            -o ./output
+            -p:UseMaui=true \
+            -p:EnableWorkloadResolver=true
 
       - name: Find APK
         id: locate_apk


### PR DESCRIPTION
## Summary by Sourcery

Update the Android build step in the GitHub Actions workflow to use dotnet build instead of publish and enable MAUI workload resolution

CI:
- Switch Android project command from 'dotnet publish' to 'dotnet build'
- Add MSBuild properties UseMaui=true and EnableWorkloadResolver=true