### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Override TargetFrameworks for Android build
+        run: |
+          echo '<Project><PropertyGroup><TargetFramework>net8.0-android</TargetFramework></PropertyGroup></Project>' > APP.Eds/APP.Eds/Directory.Build.props
+
+
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v3
         with:
@@ -40,10 +45,6 @@ jobs:
 
           echo "ANDROID_HOME=$HOME/Android/Sdk" >> $GITHUB_ENV
           echo "$HOME/Android/Sdk/platform-tools" >> $GITHUB_PATH
-
-      - name: Override TargetFrameworks for Android build
-        run: |
-          echo '<Project><PropertyGroup><TargetFramework>net8.0-android</TargetFramework></PropertyGroup></Project>' > APP.Eds/APP.Eds/Directory.Build.props
 
       - name: Restore NuGet packages
         run: dotnet restore APP.Eds/APP.Eds/APP.Eds.csproj


### PR DESCRIPTION
## Summary by Sourcery

Reposition the Android TargetFramework override step to run before .NET SDK setup and remove its duplicate instance in the GitHub Actions workflow

CI:
- Reorder "Override TargetFrameworks for Android build" step before the .NET SDK setup
- Remove the redundant duplicate TargetFramework override step