### PR TITLE
Fix Entry's colors in AddDispenser Popup

### DIFF
--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
@@ -67,7 +67,6 @@ public partial class AddDispenser : Popup
             }
 
             
-
             await courtService.AddDispenserFromPopup();
 
             vm.AddSelectedHose(vm.SelectedHose);
@@ -89,16 +88,13 @@ public partial class AddDispenser : Popup
     private void EntryAccumulatedCompleted(object sender, EventArgs e)
     {
         if (BindingContext is CourtService vm)
-        {
-            AmountBoxView.Color = vm.AccumulatedAmount >= vm.LastAccumulatedAmount ? Colors.Green : Colors.Red;
-            GallonBoxView.Color = vm.AccumulatedGallons >= vm.LastAccumulatedGallons ? Colors.Green : Colors.Red;
-            
+        {   
             if (vm.AccumulatedAmount > vm.LastAccumulatedAmount)
             {
                 vm.AccumulatedGallons = Math.Round(vm.LastAccumulatedGallons + (vm.AmountDifferenceResult / vm.SelectedHose.Price),2);
             }
-            SecondEntry.Focus();
-            SecondEntry.CursorPosition = SecondEntry.Text.Length;
+            AmountBoxView.Color = vm.AccumulatedAmount >= vm.LastAccumulatedAmount ? Colors.Green : Colors.Red;
+            GallonBoxView.Color = vm.AccumulatedGallons >= vm.LastAccumulatedGallons ? Colors.Green : Colors.Red;
         }
     }
    
@@ -106,13 +102,12 @@ public partial class AddDispenser : Popup
     {
         if (BindingContext is CourtService vm)
         {
-            AmountBoxView.Color = vm.AccumulatedAmount >= vm.LastAccumulatedAmount ? Colors.Green : Colors.Red;
-            GallonBoxView.Color = vm.AccumulatedGallons >= vm.LastAccumulatedGallons ? Colors.Green : Colors.Red;
-
             if (vm.AccumulatedAmount > vm.LastAccumulatedAmount)
             {
                 vm.AccumulatedGallons = Math.Round(vm.LastAccumulatedGallons + (vm.AmountDifferenceResult / vm.SelectedHose.Price),2);
             }
+            AmountBoxView.Color = vm.AccumulatedAmount >= vm.LastAccumulatedAmount ? Colors.Green : Colors.Red;
+            GallonBoxView.Color = vm.AccumulatedGallons >= vm.LastAccumulatedGallons ? Colors.Green : Colors.Red;
         }
     }
 


### PR DESCRIPTION
Fix Entry's colors in AddDispenser Popup

## Summary by Sourcery

Fix the color update logic for amount and gallon entries in the AddDispenser popup to ensure correct feedback after value recalculation

Bug Fixes:
- Reorder color assignments to occur after recalculating accumulated gallons in both EntryAccumulatedCompleted and OnEntryUnfocused handlers
- Remove unnecessary focus and cursor positioning on the second entry field