### PR TITLE
delete word translate

### DIFF
--- a/APP.Eds/APP.Eds/Components/PopUp/AddCourtExpenditure.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddCourtExpenditure.xaml
@@ -48,7 +48,7 @@
                            Margin="0,0,0,10">
                         <Grid RowDefinitions="*,*" ColumnDefinitions="*,*,*">
                             <Label Text="{Binding  AmountTranslation}" VerticalOptions="Center" HorizontalOptions="Center" Grid.Row="0" Grid.Column="1"/>
-                            <Entry x:Name="FirstEntry" Placeholder="Ingrese monto(traducir)" Grid.Row="1" Grid.Column="1"
+                            <Entry x:Name="FirstEntry" Placeholder="Ingrese monto" Grid.Row="1" Grid.Column="1"
                                    Text="{Binding CourtExpenditureAmount, StringFormat='{0:N0}', Mode=TwoWay}"
                                    Completed="EntryAmountCompleted" TextChanged="FirstEntry_TextChanged"
                                    IsEnabled="False" Keyboard="Numeric" HorizontalTextAlignment="Center"

--- a/APP.Eds/APP.Eds/Components/PopUp/AddCourtTypeOfCollection.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddCourtTypeOfCollection.xaml
@@ -46,7 +46,7 @@
                        Margin="0,0,0,10">
                     <Grid RowDefinitions="*,*" ColumnDefinitions="*,*,*">
                             <Label Text="{Binding CollectionAmount}" VerticalOptions="Center" HorizontalOptions="Center" Grid.Row="0" Grid.Column="1"/>
-                            <Entry x:Name="FirstEntry"   Placeholder="Ingrese el monto(traducir)" Grid.Row="1" Grid.Column="1"
+                            <Entry x:Name="FirstEntry"   Placeholder="Ingrese el monto" Grid.Row="1" Grid.Column="1"
                                Text="{Binding CourtTypeOfCollectionAmount,Mode=TwoWay, StringFormat='{0:N0}'}"
                                Completed="EntryAmountCompleted" TextChanged="FirstEntry_TextChanged"
                                IsEnabled="False" Keyboard="Numeric" HorizontalTextAlignment="Center"/>

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
@@ -46,7 +46,7 @@
                     
                     <Frame Padding="10" CornerRadius="10" HasShadow="True" Margin="0,0,0,10">
                         <Grid RowDefinitions="*,*,*,*" ColumnDefinitions="*,20,*" RowSpacing="5">
-                            <Label Text="Precio por galón(traducir)" FontAttributes="Bold" VerticalOptions="Center" HorizontalOptions="End" Grid.Row="0" Grid.Column="0"/>
+                            <Label Text="Precio por galón" FontAttributes="Bold" VerticalOptions="Center" HorizontalOptions="End" Grid.Row="0" Grid.Column="0"/>
                             <Label x:Name="PricePerGallonLabel" FontAttributes="Bold" VerticalOptions="Center" HorizontalOptions="Start" Grid.Row="0" Grid.Column="2"/>
                             <Label Text="{Binding LastAccumulatedAmountTranslation}" VerticalOptions="Center" HorizontalOptions="End" Grid.Row="1" Grid.Column="0"/>
                             <Label Text="{Binding LastAccumulatedAmount, StringFormat='$ {0:N0}'}" VerticalOptions="Center" Grid.Row="1" Grid.Column="2"/>
@@ -60,7 +60,7 @@
                                    Unfocused="OnEntryUnfocused" Completed="EntryAccumulatedCompleted"
                                    IsEnabled="False"/>
 
-                            <Label Text="Amount(traducir)" HorizontalOptions="End" Grid.Row="3" Grid.Column="0"/>
+                            <Label Text="Amount" HorizontalOptions="End" Grid.Row="3" Grid.Column="0"/>
                             <Label Text="{Binding AmountDifferenceResult, StringFormat=' $ {0:N0}'}" VerticalOptions="Center" HorizontalOptions="Start" Grid.Row="3" Grid.Column="2"/>
                         </Grid>
                         
@@ -81,7 +81,7 @@
                                    Unfocused="OnEntryUnfocused" Completed="EntryGallonsCompleted"
                                    IsEnabled="False"/>
 
-                            <Label Text="Gallons (traducir) " VerticalOptions="Center" HorizontalOptions="End" Grid.Row="2" Grid.Column="0"/>
+                            <Label Text="Gallons " VerticalOptions="Center" HorizontalOptions="End" Grid.Row="2" Grid.Column="0"/>
                             <Label Text="{Binding GallonsDifferenceResult, StringFormat='  {0:N2}'}" VerticalOptions="Center" HorizontalOptions="Start" Grid.Row="2" Grid.Column="2"/>
 
                             <Button Text="✎"
@@ -102,7 +102,7 @@
                     BackgroundColor="#6200E8"
                     Clicked="Add_Dispenser"
                     CornerRadius="10"
-                    FontSize="18" Text="Add(traducir)" TextColor="White"
+                    FontSize="18" Text="Add" TextColor="White"
                     VerticalOptions="Center"
                     HeightRequest="40"/>
         </Grid>

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDocuemt.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDocuemt.xaml
@@ -19,7 +19,7 @@
 
             <!--  Encabezado  -->
             <Grid Grid.Row="0" ColumnDefinitions="*, Auto, *" Padding="0,0,0,10">
-                <Label Grid.Column="1" FontAttributes="Bold" FontSize="22" Text="AddDocumentTranslation(traducir)" HorizontalTextAlignment="Center" HorizontalOptions="Center" VerticalOptions="Center"/>
+                <Label Grid.Column="1" FontAttributes="Bold" FontSize="22" Text="AddDocumentTranslation" HorizontalTextAlignment="Center" HorizontalOptions="Center" VerticalOptions="Center"/>
                 <Button Grid.Column="2"
                         BackgroundColor="Transparent"
                         Clicked="OnCloseTapped"
@@ -41,11 +41,11 @@
 						Clicked="OnSelectFileClicked"
                         AutomationId="SelectFileButton"
 						CornerRadius="10"
-						Text="Select File(traducit)"/>
+						Text="Select File"/>
 					<Label
 						FontAttributes="Bold"
 						IsVisible="{Binding IsFileSelected}"
-						Text="Selected File:(traducir)"
+						Text="Selected File:"
                         AutomationId="SelectedFileLabel"/>
 					<Label
 						FontAttributes="Italic"
@@ -62,7 +62,7 @@
                     AutomationId="AddButton"
                     CornerRadius="10"
                     FontSize="18"
-                    Text="Add(traducir)"
+                    Text="Add"
                     TextColor="White"
                     VerticalOptions="Center"
                     HeightRequest="40"/>

--- a/APP.Eds/APP.Eds/Components/PopUp/AddInfo.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddInfo.xaml
@@ -18,7 +18,7 @@
 
             <!--  Encabezado  -->
             <Grid Grid.Row="0" ColumnDefinitions="*, Auto, *" Padding="0,0,0,10">
-                <Label Grid.Column="1" FontAttributes="Bold" FontSize="22" Text="Agregar Informacion Extra(traducir)" HorizontalTextAlignment="Center" HorizontalOptions="Center" VerticalOptions="Center"/>
+                <Label Grid.Column="1" FontAttributes="Bold" FontSize="22" Text="Agregar Informacion Extra" HorizontalTextAlignment="Center" HorizontalOptions="Center" VerticalOptions="Center"/>
                 <Button Grid.Column="2" Margin="10,0,0,0"
                         BackgroundColor="Transparent"
                         Clicked="OnCloseTapped"

--- a/APP.Eds/APP.Eds/Components/PopUp/AddShopping.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddShopping.xaml
@@ -17,7 +17,7 @@
 
             <!--  Encabezado  -->
             <Grid Grid.Row="0" ColumnDefinitions="*,Auto,*" Padding="0,0,0,10">
-                <Label Text="Nuevo Producto(traducir)" FontAttributes="Bold" FontSize="22" Grid.Row="0" Grid.Column="1"
+                <Label Text="Nuevo Producto" FontAttributes="Bold" FontSize="22" Grid.Row="0" Grid.Column="1"
                        HorizontalTextAlignment="Center" HorizontalOptions="Center" VerticalOptions="Center"/>
                 <Button Grid.Column="2"
                         BackgroundColor="Transparent"
@@ -31,8 +31,8 @@
                 <VerticalStackLayout>
                     <Frame Padding="10" CornerRadius="10" HasShadow="True" Margin="0,0,0,10">
                         <Grid RowDefinitions="*,*" ColumnDefinitions="*">
-                            <Label FontSize="16" Text="Producto(traducir)" HorizontalOptions="Center" Grid.Row="0"/>
-                            <Picker x:Name="ProductPicker" Title="Seleccione un producto(traducir)"  Grid.Row="1"
+                            <Label FontSize="16" Text="Producto" HorizontalOptions="Center" Grid.Row="0"/>
+                            <Picker x:Name="ProductPicker" Title="Seleccione un producto"  Grid.Row="1"
                                     ItemsSource="{Binding ProductList}" ItemDisplayBinding="{Binding Name}" SelectedItem="{Binding SelectedProduct, Mode=TwoWay}"
                                     SelectedIndexChanged="ProductSelected" HorizontalTextAlignment="Center"/>
                         </Grid>
@@ -40,8 +40,8 @@
 
                     <Frame Padding="10" CornerRadius="10" HasShadow="True" Margin="0,0,0,10">
                         <Grid RowDefinitions="*,*" ColumnDefinitions="*">
-                            <Label Text="Compartimiento destino(traducir)" HorizontalOptions="Center" Grid.Row="0"/>
-                            <Picker x:Name="CompartimentPicker" Title="Seleccione un compartimiento(traducir)" Grid.Row="1"
+                            <Label Text="Compartimiento destino" HorizontalOptions="Center" Grid.Row="0"/>
+                            <Picker x:Name="CompartimentPicker" Title="Seleccione un compartimiento" Grid.Row="1"
                                     ItemsSource="{Binding CompartimentList}" ItemDisplayBinding="{Binding DisplayCompartiment}" SelectedItem="{Binding SelectedCompartiment, Mode=TwoWay}"
                                     IsEnabled="False" SelectedIndexChanged="CompartimentSelected"  HorizontalTextAlignment="Center"/>
                         </Grid>
@@ -49,9 +49,9 @@
 
                     <Frame Padding="10" CornerRadius="10" HasShadow="True" Margin="0,0,0,10">
                         <Grid RowDefinitions="*,*" ColumnDefinitions="*">
-                            <Label Text="Precio de compra por galon(traducir)" HorizontalOptions="Center" Grid.Row="0"/>
+                            <Label Text="Precio de compra por galon" HorizontalOptions="Center" Grid.Row="0"/>
                             <Entry x:Name="FirstEntry" Keyboard="Numeric" Grid.Row="1"
-                                   Placeholder="Ingrese el precio de compra por galon(traducir)" HorizontalTextAlignment="Center"
+                                   Placeholder="Ingrese el precio de compra por galon" HorizontalTextAlignment="Center"
                                    Text="{Binding Price, Mode=TwoWay, StringFormat='{0:N0}'}"
                                    Completed="EntryPriceCompleted"
                                    IsEnabled="False"/>
@@ -60,9 +60,9 @@
 
                     <Frame Padding="10" CornerRadius="10" HasShadow="True" Margin="0,0,0,10">
                         <Grid RowDefinitions="*,*" ColumnDefinitions="*">
-                            <Label Text="Cantidad(traducir)" HorizontalOptions="Center" Grid.Row="0"/>
+                            <Label Text="Cantidad" HorizontalOptions="Center" Grid.Row="0"/>
                             <Entry x:Name="SecondEntry" Keyboard="Numeric" Grid.Row="1"
-                                   Placeholder="Ingrese la cantidad de galones(traducir)" HorizontalTextAlignment="Center"
+                                   Placeholder="Ingrese la cantidad de galones" HorizontalTextAlignment="Center"
                                    Text="{Binding Quantity, Mode=TwoWay, StringFormat='{0:N0}'}"
                                    IsEnabled="False" Completed="EntryQuantityCompleted"/>
                         </Grid>
@@ -70,9 +70,9 @@
 
                     <Frame Padding="10" CornerRadius="10" HasShadow="True" Margin="0,0,0,10">
                         <Grid RowDefinitions="*,*" ColumnDefinitions="*">
-                            <Label Text="Precio de venta por galon(traducir)" HorizontalOptions="Center" Grid.Row="0"/>
+                            <Label Text="Precio de venta por galon" HorizontalOptions="Center" Grid.Row="0"/>
                             <Entry x:Name="ThirdEntry" Keyboard="Numeric" Grid.Row="1"
-                                   Placeholder="Ingrese el precio de venta por galon(traducir)" HorizontalTextAlignment="Center"
+                                   Placeholder="Ingrese el precio de venta por galon" HorizontalTextAlignment="Center"
                                    Text="{Binding SellPrice, Mode=TwoWay, StringFormat='{0:N0}'}"
                                    IsEnabled="False" Completed="Add_Product"/>
                         </Grid>
@@ -85,7 +85,7 @@
                     BackgroundColor="#6200E8"
                     Clicked="Add_Product"
                     CornerRadius="10"
-                    FontSize="18" Text="Agregar Egreso(traducir)" TextColor="White"/>
+                    FontSize="18" Text="Agregar Egreso" TextColor="White"/>
         </Grid>
     </Frame>
 </mct:Popup>

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
@@ -80,7 +80,7 @@
                             <Label Text="{Binding TotalSales, StringFormat='$ {0:N0}'}" VerticalOptions="Center" Grid.Row="5" Grid.Column="1" HorizontalOptions="Center" />
                  
                             <Label Text="{Binding DistinticDescription}" Grid.Row="4" Grid.Column="2" HorizontalOptions="Center" />
-                            <Entry Keyboard="Numeric" Placeholder="Ingrese el distintic (traducir)" Text="{Binding Distintic, Mode=TwoWay}" Grid.Row="5" Grid.Column="2" HorizontalOptions="Center" HorizontalTextAlignment="Center"/>
+                            <Entry Keyboard="Numeric" Placeholder="Ingrese el distintic" Text="{Binding Distintic, Mode=TwoWay}" Grid.Row="5" Grid.Column="2" HorizontalOptions="Center" HorizontalTextAlignment="Center"/>
                         </Grid>
                     </VerticalStackLayout>
                 </Frame>
@@ -111,13 +111,13 @@
                         <DataTemplate>
                             <Frame Margin="5" Padding="10" BorderColor="LightGray" CornerRadius="8">
                                 <Grid ColumnDefinitions="Auto,20,*,Auto" RowDefinitions="Auto,Auto,Auto" RowSpacing="5">
-                                    <Label Text="Number(traducir)" FontAttributes="Bold" Grid.Row="0" Grid.Column="0"/>
+                                    <Label Text="Number" FontAttributes="Bold" Grid.Row="0" Grid.Column="0"/>
                                     <Label Text="{Binding NumberName}" Grid.Row="0" Grid.Column="2"/>
 
-                                    <Label Text="Accumulated Amount(traducir" FontAttributes="Bold" Grid.Row="1" Grid.Column="0"/>
+                                    <Label Text="Accumulated Amount" FontAttributes="Bold" Grid.Row="1" Grid.Column="0"/>
                                     <Label Text="{Binding AccumulatedAmount, StringFormat='$ {0:N0}'}" Grid.Row="1" Grid.Column="2"/>
 
-                                    <Label Text="Gallons Accumulated(traducir)" FontAttributes="Bold" Grid.Row="2" Grid.Column="0"/>
+                                    <Label Text="Gallons Accumulated" FontAttributes="Bold" Grid.Row="2" Grid.Column="0"/>
                                     <Label Text="{Binding AccumulatedGallons, StringFormat='{0:N2}'}" Grid.Row="2" Grid.Column="2"/>
 
                                     <Button Text="X" 
@@ -138,7 +138,7 @@
 
                 <!-- Documents con botón de eliminar -->
                 <Grid ColumnDefinitions="*, Auto" x:Name="AddedDocuments">
-                    <Label Text="AddedDocuments(traducir)" FontAttributes="Bold" FontSize="18" Grid.ColumnSpan="2" VerticalOptions="Center" HorizontalOptions="Center"/>
+                    <Label Text="AddedDocuments" FontAttributes="Bold" FontSize="18" Grid.ColumnSpan="2" VerticalOptions="Center" HorizontalOptions="Center"/>
                     <Button  Text="�️"
                              Command="{Binding HideDocumentList}"
                              AutomationId="HideDocumentListButton"

--- a/APP.Eds/APP.Eds/UsesCases/Shopping/ShoppingPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Shopping/ShoppingPostView.xaml
@@ -3,22 +3,22 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="APP.Eds.UsesCases.Shopping.ShoppingPostView"
              xmlns:controls="clr-namespace:APP.Eds.UsesCases.LoadingView"
-             Title="Gestion Shopping(Traducir)">
+             Title="Gestion Shopping">
 
     <AbsoluteLayout>
         <ScrollView AbsoluteLayout.LayoutBounds="0,0,1,1" AbsoluteLayout.LayoutFlags="All" x:Name="MainContent">
             <VerticalStackLayout Padding="20" Spacing="15">
 
-                <Label FontSize="16" Text="Invoice(traducir)"/>
+                <Label FontSize="16" Text="Invoice"/>
                 <Entry Keyboard="Text" Placeholder="Enter Invoice" Text="{Binding Invoice, Mode=TwoWay}"/>
 
-                <Label FontSize="16" Text="Date(traducir)"/>
+                <Label FontSize="16" Text="Date"/>
                 <DatePicker Date="{Binding Date, Mode=TwoWay}" Format="dd/MM/yyyy" MinimumDate="2000-01-01" MaximumDate="2100-12-31"/>
 
-                <Label FontSize="16" Text="Provider(traducir)"/>
+                <Label FontSize="16" Text="Provider"/>
                 <Picker Title="Seleccione un Proveedor" ItemsSource="{Binding ProviderList}" ItemDisplayBinding="{Binding Name}" SelectedItem="{Binding SelectedProvider, Mode=TwoWay}"/>
 
-                <Label FontSize="16" Text="Category(traducir)"/>
+                <Label FontSize="16" Text="Category"/>
                 <Picker Title="Seleccione una Categoria" ItemsSource="{Binding CategoryList}" ItemDisplayBinding="{Binding Description}" SelectedItem="{Binding SelectedCategory, Mode=TwoWay}"/>
 
 


### PR DESCRIPTION
delete word translate

## Summary by Sourcery

Enhancements:
- Remove 'Translate' descriptors from form labels across several pop-up components and post views