### PR TITLE
Feature/manage permissions

### DIFF
--- a/APP.Eds/APP.Eds/MainPage.xaml.cs
+++ b/APP.Eds/APP.Eds/MainPage.xaml.cs
@@ -76,7 +76,10 @@ namespace APP.Eds
 
                 var tokenPayload = JsonSerializer.Deserialize<JsonElement>(jsonPayload);
 
-               
+                var Username = tokenPayload.GetProperty("preferred_username").GetString();
+
+                Preferences.Set("Usernamelogin", Username);
+
                 var roles = tokenPayload
                     .GetProperty("resource_access")
                     .GetProperty("application-eds")
@@ -93,9 +96,9 @@ namespace APP.Eds
                     Preferences.Set("userRole", "Admin");
                     Application.Current.MainPage = new NavigationPage(new Main());
                 }
-                else if (roles.Contains("Islander"))
+                else if (roles.Contains("User"))
                 {
-                    Preferences.Set("userRole", "Islander");
+                    Preferences.Set("userRole", "User");
                     Application.Current.MainPage = new NavigationPage(new Main());
                 }
                 else

--- a/APP.Eds/APP.Eds/MainPage.xaml.cs
+++ b/APP.Eds/APP.Eds/MainPage.xaml.cs
@@ -85,36 +85,25 @@ namespace APP.Eds
                     .Select(r => r.GetString())
                     .ToList();
 
-                Dictionary<string, bool> config = new Dictionary<string, bool>();
-                if (tokenPayload.TryGetProperty("Config", out JsonElement configElement))
-                {
-                    foreach (var prop in configElement.EnumerateObject())
-                    {
-                        config[prop.Name] = prop.Value.GetBoolean();
-                    }
-                }
-
-                var configJson = JsonSerializer.Serialize(config);
-                Preferences.Set("userConfig", configJson);
-
-
                 TokenHelper.SaveToken(token, _clientId, _realm);
 
-                
+
                 if (roles.Contains("Admin"))
                 {
                     Preferences.Set("userRole", "Admin");
                     Application.Current.MainPage = new NavigationPage(new Main());
                 }
-                else if (roles.Contains("User"))
+                else if (roles.Contains("Islander"))
                 {
-                    Preferences.Set("userRole", "User");
+                    Preferences.Set("userRole", "Islander");
                     Application.Current.MainPage = new NavigationPage(new Main());
                 }
                 else
                 {
                     ShowError("Rol no autorizado.");
                 }
+
+
 
             }
             catch (Exception ex)
@@ -136,43 +125,6 @@ namespace APP.Eds
             ErrorLabel.IsVisible = true;
         }
 
-        
-        //private void SaveToken(string token, string clientId, string realm)
-        //{
-
-            
-            
-        //    Preferences.Set("CURRENT_AUTH_REALM", realm);
-        //    Preferences.Set("CURRENT_AUTH_CLIENT_ID", clientId);
-
-            
-        //    string prefix = $"AUTH_{realm}_{clientId}_";
-        //    var tokenParts = SplitTokenIntoParts(token);  
-        //    Preferences.Set($"{prefix}TOKEN_PART_COUNT", tokenParts.Length);
-
-        //    for (int i = 0; i < tokenParts.Length; i++)
-        //    {
-        //        Preferences.Set($"{prefix}TOKEN_PART_{i}", tokenParts[i]);
-        //    }
-        //}
-
-        
-        //private string[] SplitTokenIntoParts(string token)
-        //{
-        //    const int chunkSize = 512; 
-        //    int partCount = (int)Math.Ceiling((double)token.Length / chunkSize);
-
-        //    var parts = new string[partCount];
-        //    for (int i = 0; i < partCount; i++)
-        //    {
-        //        int startIndex = i * chunkSize;
-        //        int length = Math.Min(chunkSize, token.Length - startIndex);
-        //        parts[i] = token.Substring(startIndex, length);
-        //    }
-
-        //    return parts;
-        //}
-
         private string PadBase64(string base64)
         {
             switch (base64.Length % 4)
@@ -188,30 +140,5 @@ namespace APP.Eds
         {
             PasswordEntry.Focus();
         }
-
-
-        //private string LoadToken(string clientId, string realm)
-        //{
-        //    try
-        //    {
-        //        string prefix = $"AUTH_{realm}_{clientId}_";
-
-
-        //        int chunkCount = Preferences.Get($"{prefix}TOKEN_PART_COUNT", 0);
-        //        if (chunkCount == 0) return null; 
-
-        //        var tokenBuilder = new StringBuilder();
-        //        for (int i = 0; i < chunkCount; i++)
-        //        {
-        //            tokenBuilder.Append(Preferences.Get($"{prefix}TOKEN_PART_{i}", string.Empty));
-        //        }
-        //        return tokenBuilder.ToString();  
-        //    }
-        //    catch (Exception ex)
-        //    {
-        //        Debug.WriteLine($"Error loading token: {ex}");
-        //        return null;
-        //    }
-        //}
     }
 }

--- a/APP.Eds/APP.Eds/Services/Authentication/IKeycloakSessionManager.cs.cs
+++ b/APP.Eds/APP.Eds/Services/Authentication/IKeycloakSessionManager.cs.cs
@@ -1,4 +1,6 @@
 ﻿
+using APP.Eds.Services.Court;
+
 namespace APP.Eds.Services.Authentication
 {
     public class KeycloakSessionManager
@@ -27,6 +29,8 @@ namespace APP.Eds.Services.Authentication
             string clientId = "application-eds";
 
             ClearSession(realm, clientId);
+
+            CourtService.DestroyInstance();
 
             Console.WriteLine($"Current session cleared for realm={realm}, clientId={clientId}");
         }

--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -27,6 +27,8 @@ namespace APP.Eds.Services.Court
     {
         public bool LastSendWasSuccessful { get; private set; }
         public string UserRole { get; set; } = string.Empty;
+        public bool IsUserRole => Preferences.Get("userRole", "") == "User";
+
         private static CourtService _instance;
         public static CourtService Instance => _instance ??= new CourtService();
 
@@ -51,9 +53,13 @@ namespace APP.Eds.Services.Court
             _instance.AdditionalInfoDescription = null;
             
         }
+        public static void DestroyInstance()
+        {
+            _instance = null;
+        }
 
-       
-                 
+
+
         public ObservableCollection<EdsCourtModel> EdsList { get; set; } = [];
         public ObservableCollection<EdsCourtModel> EdsSelectList { get; set; } = [];
         public ObservableCollection<ProductCourtModel> ProductList { get; set; } = [];
@@ -69,9 +75,9 @@ namespace APP.Eds.Services.Court
         public ObservableCollection<double> AmountResults { get; set; } = new ObservableCollection<double>();
         public ObservableCollection<double> GallonResults { get; set; } = new ObservableCollection<double>();
         public ObservableCollection<CourtListItemModel> CourtList { get; set; } = new();
-        public bool AreAvailableHoses => HoseDispenserList != null && HoseDispenserList.Count > 0;
-        public bool NewSaleEnabled => (IsEdsSelected && AreAvailableHoses);
-        public bool AdditionalInfoEnabled => !string.IsNullOrEmpty(AdditionalInfoDescription);
+        public bool AreAvailableHoses => IsUserRole || HoseDispenserList != null && HoseDispenserList.Count > 0;
+        public bool NewSaleEnabled => IsUserRole || (IsEdsSelected && AreAvailableHoses);
+        public bool AdditionalInfoEnabled => IsUserRole || !string.IsNullOrEmpty(AdditionalInfoDescription);
 
         private List<HoseCourtModel> selectedHoses = new List<HoseCourtModel>();
 
@@ -127,6 +133,7 @@ namespace APP.Eds.Services.Court
                 OnPropertyChanged(nameof(IdIslander));
             }
         }
+
 
         private DateTime _dateStarttime;
         public DateTime DateStarttime
@@ -728,7 +735,7 @@ namespace APP.Eds.Services.Court
         private bool _isEdsSelected;
         public bool IsEdsSelected
         {
-            get => _isEdsSelected;
+            get => IsUserRole || _isEdsSelected;
             set
             {
                 _isEdsSelected = value;
@@ -2384,7 +2391,6 @@ GetAllEdsData()
                 }
             }
 
-
         }
 
         private async void LoadLastAccumulated(int idDispenser, int idHose)
@@ -2846,6 +2852,7 @@ GetAllEdsData()
                 Court.IdIslander = IdIslander;
 
                 UserRole = Preferences.Get("userRole", string.Empty);
+
                 if (UserRole == "User")
                 {
                     Court.IdBusiness = int.Parse(Preferences.Get("businessId", string.Empty));

--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -26,7 +26,7 @@ namespace APP.Eds.Services.Court
 
     {
         public bool LastSendWasSuccessful { get; private set; }
-
+        public string UserRole { get; set; } = string.Empty;
         private static CourtService _instance;
         public static CourtService Instance => _instance ??= new CourtService();
 
@@ -52,7 +52,8 @@ namespace APP.Eds.Services.Court
             
         }
 
-
+       
+                 
         public ObservableCollection<EdsCourtModel> EdsList { get; set; } = [];
         public ObservableCollection<EdsCourtModel> EdsSelectList { get; set; } = [];
         public ObservableCollection<ProductCourtModel> ProductList { get; set; } = [];
@@ -69,7 +70,7 @@ namespace APP.Eds.Services.Court
         public ObservableCollection<double> GallonResults { get; set; } = new ObservableCollection<double>();
         public ObservableCollection<CourtListItemModel> CourtList { get; set; } = new();
         public bool AreAvailableHoses => HoseDispenserList != null && HoseDispenserList.Count > 0;
-        public bool NewSaleEnabled => IsEdsSelected && AreAvailableHoses;
+        public bool NewSaleEnabled => (IsEdsSelected && AreAvailableHoses);
         public bool AdditionalInfoEnabled => !string.IsNullOrEmpty(AdditionalInfoDescription);
 
         private List<HoseCourtModel> selectedHoses = new List<HoseCourtModel>();
@@ -2251,6 +2252,8 @@ namespace APP.Eds.Services.Court
 
         public CourtService()
         {
+           
+
             _authToken = TokenHelper.LoadToken(Configuration.KeycloakCliendId, Configuration.KeycloakRealms);
             //OcultarListas
 
@@ -2841,6 +2844,16 @@ GetAllEdsData()
                 Court.IdBusiness = IdBusiness;
                 Court.IdEds = IdEds;
                 Court.IdIslander = IdIslander;
+
+                UserRole = Preferences.Get("userRole", string.Empty);
+                if (UserRole == "User")
+                {
+                    Court.IdBusiness = int.Parse(Preferences.Get("businessId", string.Empty));
+                    Court.IdEds = int.Parse(Preferences.Get("edsId", string.Empty));
+                    Court.IdIslander = int.Parse(Preferences.Get("islanderId", string.Empty));
+                }
+            
+               
                 Court.DateStarttime = DateStarttime.ToString("yyyy-MM-dd");
                 Court.Starttime = Starttime.ToString(@"hh\:mm\:ss");
                 Court.DateEndtime = DateEndtime.ToString("yyyy-MM-dd");

--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -29,6 +29,7 @@ namespace APP.Eds.Services.Court
 
         private static CourtService _instance;
         public static CourtService Instance => _instance ??= new CourtService();
+
         private string? _authToken;
 
         public static void ResetInstanceFields()
@@ -2308,36 +2309,46 @@ GetAllEdsData()
                 
                 using var httpClient = new HttpClient();
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
+
+                var businessResponse = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/business?PageNumber=1&PageSize=100");
                 var IslanderResponse = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/islander?PageNumber=1&PageSize=100");
                 var edsResponse = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/eds?PageNumber=1&PageSize=100");
+
+
+
+                var businessList = JsonSerializer.Deserialize<BusinessResponseModel>(businessResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                var IslanderList = JsonSerializer.Deserialize<IslanderApiResponse>(IslanderResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                var edsList = JsonSerializer.Deserialize<EdsCourtResponseModel>(edsResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+
+                UpdateEdsList(edsList?.Data ?? new List<EdsCourtModel>());
+                UpdateIslanderList(IslanderList?.Data ?? new List<IslanderResponse>());
+                UpdateBusiness(businessList?.Data ?? new List<BusinessModel>());
+
                 var productResponse = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/product?PageNumber=1&PageSize=100");
                 var compartimentResponse = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/compartiment?PageNumber=1&PageSize=100");
                 var hoseResponse = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/hose?PageNumber=1&PageSize=100");
                 var expenditureResponse = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/expenditures?PageNumber=1&PageSize=100");
                 var typeOfCollectionResponse = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/type-of-collection?PageNumber=1&PageSize=100");
-                var businessResponse = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/business?PageNumber=1&PageSize=100");
+                
                 var dispensersResponse = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/dispensers?PageNumber=1&PageSize=100");
-               
 
-                var IslanderList = JsonSerializer.Deserialize<IslanderApiResponse>(IslanderResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                var edsList = JsonSerializer.Deserialize<EdsCourtResponseModel>(edsResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                
                 var productList = JsonSerializer.Deserialize<ProductCourtResponseModel>(productResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                 var compartimentList = JsonSerializer.Deserialize<CompartimentCourtResponseModel>(compartimentResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                 var hoseList = JsonSerializer.Deserialize<HoseCourtResponseModel>(hoseResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                 var expenditureList = JsonSerializer.Deserialize<ExpenditureCourtResponseModel>(expenditureResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                 var typeOfCollectionList = JsonSerializer.Deserialize<TypeOfCollectionResponseModel>(typeOfCollectionResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                var businessList = JsonSerializer.Deserialize<BusinessResponseModel>(businessResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+     
                 var dispensersList = JsonSerializer.Deserialize<DispensersResponseModel>(dispensersResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
                
-                UpdateEdsList(edsList?.Data ?? new List<EdsCourtModel>());
-                UpdateIslanderList(IslanderList?.Data ?? new List<IslanderResponse>());
                 UpdateProductList(productList?.Data ?? new List<ProductCourtModel>());
                 UpdateCompartiment(compartimentList?.Data ?? new List<CompartimentCourtModel>());
                 UpdateHose(hoseList?.Data ?? new List<HoseCourtModel>());
                 UpdateCourtExpenditure(expenditureList?.Data ?? new List<ExpendituresCourtModel>());
                 UpdateTypeOfCollection(typeOfCollectionList?.Data ?? new List<TypeOfCollectionCourtModel>());
-                UpdateBusiness(businessList?.Data ?? new List<BusinessModel>());
+                
                 UpdateDispensers(dispensersList?.Data ?? new List<DispenserModelResponse>());
 
             }
@@ -2347,6 +2358,30 @@ GetAllEdsData()
 
 
             }
+
+            var username = Preferences.Get("Usernamelogin", "");
+
+            var islander = IslanderList.FirstOrDefault(i => i.Name == username);
+            if (islander != null)
+            {
+                Preferences.Set("islanderId", islander.IdIslander.ToString());
+
+                var eds = EdsList.FirstOrDefault(e => e.IdEds == islander.IdEds);
+                if (eds != null)
+                {
+                    Preferences.Set("edsId", eds.IdEds.ToString());
+                    Preferences.Set("edsName", eds.Name);
+
+                    var business = BusinessList.FirstOrDefault(b => b.IdBusiness == eds.IdBusiness);
+                    if (business != null)
+                    {
+                        Preferences.Set("businessId", business.IdBusiness.ToString());
+                        Preferences.Set("businessName", business.Name);
+                    }
+                }
+            }
+
+
         }
 
         private async void LoadLastAccumulated(int idDispenser, int idHose)

--- a/APP.Eds/APP.Eds/Services/Navigation/MainService.cs
+++ b/APP.Eds/APP.Eds/Services/Navigation/MainService.cs
@@ -32,7 +32,7 @@ namespace APP.Eds.Services.Navigation
     public class MainService : BindableObject
     {
         public ObservableCollection<CategoryModel> Categories { get; set; }
-        public bool IsIslander => Preferences.Get("userRole", "") == "Islander";
+        public bool IsIslander => Preferences.Get("userRole", "") == "User";
         public ICommand NavigateToCourtCommand { get; }
         public MainService()
         {
@@ -41,8 +41,7 @@ namespace APP.Eds.Services.Navigation
             {
                 if (Application.Current?.MainPage is NavigationPage navPage)
                 {
-                    var page = (Page)Activator.CreateInstance(typeof(CourtPostView));
-                    await navPage.PushAsync(page);
+                    await navPage.PushAsync(new CourtPostView());
                 }
             });
 

--- a/APP.Eds/APP.Eds/Services/Navigation/MainService.cs
+++ b/APP.Eds/APP.Eds/Services/Navigation/MainService.cs
@@ -32,10 +32,24 @@ namespace APP.Eds.Services.Navigation
     public class MainService : BindableObject
     {
         public ObservableCollection<CategoryModel> Categories { get; set; }
-
+        public bool IsIslander => Preferences.Get("userRole", "") == "Islander";
+        public ICommand NavigateToCourtCommand { get; }
         public MainService()
         {
-            Categories = new ObservableCollection<CategoryModel>
+
+            NavigateToCourtCommand = new Command(async () =>
+            {
+                if (Application.Current?.MainPage is NavigationPage navPage)
+                {
+                    var page = (Page)Activator.CreateInstance(typeof(CourtPostView));
+                    await navPage.PushAsync(page);
+                }
+            });
+
+            if (!IsIslander)
+            {
+
+                Categories = new ObservableCollection<CategoryModel>
             {
                 new("Administración", new List<MenuItemModel>
                 {
@@ -80,6 +94,11 @@ namespace APP.Eds.Services.Navigation
                  
                 ]),
             };
+            }
+            else
+            {
+                Categories = new ObservableCollection<CategoryModel>();
+            }
         }
 
         public class CategoryModel

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
@@ -17,7 +17,9 @@ public partial class CourtPostView : ContentPage
     {
 
         InitializeComponent();
-        _service = CourtService.Instance;
+
+        _service = UserRole == "Admin" ? CourtService.Instance : new CourtService();
+
         _service.DateStarttime = DateTime.Today;
         BindingContext = _service;
         datePicker.MinimumDate = new DateTime(1900, 1, 1);
@@ -44,14 +46,33 @@ public partial class CourtPostView : ContentPage
             LoadingOverlay.ShowLoading();
             MainContent.IsVisible = false;
 
-            if (_service.BusinessList == null || !_service.BusinessList.Any())
-            {
-                await _service.GetAllEdsData();
-            }
+            //if (_service.BusinessList == null || !_service.BusinessList.Any())
+            //{
+            //    await _service.GetAllEdsData();
+            //}
+            await _service.GetAllEdsData();
 
-            if (UserRole == "Islander")
+            if (UserRole == "User")
             {
-                Business.IsVisible = false;
+
+                
+
+                var businessId = Preferences.Get("businessId", string.Empty);
+                var edsId = Preferences.Get("edsId", string.Empty);
+                var islanderId = Preferences.Get("islanderId", string.Empty);
+
+                if (_service.BusinessList?.Any() == true && int.TryParse(businessId, out var parsedBusinessId))
+                    _service.SelectedBusiness = _service.BusinessList.FirstOrDefault(b => b.IdBusiness == parsedBusinessId);
+
+                if (_service.EdsSelectList?.Any() == true && int.TryParse(edsId, out var parsedEdsId))
+                    _service.SelectedEds = _service.EdsSelectList.FirstOrDefault(e => e.IdEds == parsedEdsId);
+
+                if (_service.IslanderSelectList?.Any() == true && int.TryParse(islanderId, out var parsedIslanderId))
+                    _service.SelectedIslander = _service.IslanderSelectList.FirstOrDefault(i => i.IdIslander == parsedIslanderId);
+
+
+
+                Business.IsVisible = true;
             }
 
             await _service.LoadTranslationsAsync();

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
@@ -49,6 +49,11 @@ public partial class CourtPostView : ContentPage
                 await _service.GetAllEdsData();
             }
 
+            if (UserRole == "Islander")
+            {
+                Business.IsVisible = false;
+            }
+
             await _service.LoadTranslationsAsync();
         }
         catch (Exception ex)

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
@@ -45,35 +45,8 @@ public partial class CourtPostView : ContentPage
         {
             LoadingOverlay.ShowLoading();
             MainContent.IsVisible = false;
-
-            //if (_service.BusinessList == null || !_service.BusinessList.Any())
-            //{
-            //    await _service.GetAllEdsData();
-            //}
-            await _service.GetAllEdsData();
-
-            if (UserRole == "User")
-            {
-
-                
-
-                var businessId = Preferences.Get("businessId", string.Empty);
-                var edsId = Preferences.Get("edsId", string.Empty);
-                var islanderId = Preferences.Get("islanderId", string.Empty);
-
-                if (_service.BusinessList?.Any() == true && int.TryParse(businessId, out var parsedBusinessId))
-                    _service.SelectedBusiness = _service.BusinessList.FirstOrDefault(b => b.IdBusiness == parsedBusinessId);
-
-                if (_service.EdsSelectList?.Any() == true && int.TryParse(edsId, out var parsedEdsId))
-                    _service.SelectedEds = _service.EdsSelectList.FirstOrDefault(e => e.IdEds == parsedEdsId);
-
-                if (_service.IslanderSelectList?.Any() == true && int.TryParse(islanderId, out var parsedIslanderId))
-                    _service.SelectedIslander = _service.IslanderSelectList.FirstOrDefault(i => i.IdIslander == parsedIslanderId);
-
-
-
-                Business.IsVisible = true;
-            }
+            Business.IsVisible = (UserRole is  "Admin");
+            
 
             await _service.LoadTranslationsAsync();
         }

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
@@ -18,7 +18,7 @@ public partial class CourtPostView : ContentPage
 
         InitializeComponent();
 
-        _service = UserRole == "Admin" ? CourtService.Instance : new CourtService();
+        _service = CourtService.Instance;
 
         _service.DateStarttime = DateTime.Today;
         BindingContext = _service;
@@ -45,7 +45,7 @@ public partial class CourtPostView : ContentPage
         {
             LoadingOverlay.ShowLoading();
             MainContent.IsVisible = false;
-            Business.IsVisible = (UserRole is  "Admin");
+            Business.IsVisible = (UserRole is "Admin");
             
 
             await _service.LoadTranslationsAsync();
@@ -105,21 +105,25 @@ public partial class CourtPostView : ContentPage
             double totalTypeOfCollection = vm.GetTotalTypeOfCollection();
             double totalExpenditures = vm.GetTotalExpenditure();
 
-            if (vm.SelectedBusiness is null)
+            if (UserRole == "Admin")
             {
-                await DisplayAlert("Error", "Por favor, seleccione un Negocio", "OK");
-                return;
+                if (vm.SelectedBusiness is null)
+                {
+                    await DisplayAlert("Error", "Por favor, seleccione un Negocio", "OK");
+                    return;
+                }
+                if (vm.SelectedEds is null)
+                {
+                    await DisplayAlert("Error", "Por favor, seleccione un EDS", "OK");
+                    return;
+                }
+                if (vm.SelectedIslander is null)
+                {
+                    await DisplayAlert("Error", "Por favor, seleccione un Isle�o", "OK");
+                    return;
+                }
             }
-            if (vm.SelectedEds is null)
-            {
-                await DisplayAlert("Error", "Por favor, seleccione un EDS", "OK");
-                return;
-            }
-            if (vm.SelectedIslander is null)
-            {
-                await DisplayAlert("Error", "Por favor, seleccione un Isle�o", "OK");
-                return;
-            }
+
             if (vm.CourtDispensers == null || !vm.CourtDispensers.Any())
             {
                 await DisplayAlert("Error", "Debe agregar al menos un dispensador", "OK");

--- a/APP.Eds/APP.Eds/UsesCases/Navigation/Main.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Navigation/Main.xaml
@@ -8,6 +8,14 @@
         <ScrollView>
             <VerticalStackLayout Padding="20">
                 <Label Margin="0,10,0,20" FontSize="20" HorizontalOptions="Center" Text="Menu Principal(traducir)" />
+
+                <Button Text="Court"
+                        Command="{Binding NavigateToCourtCommand}"
+                        IsVisible="{Binding IsIslander}"
+                        HeightRequest="50"
+                        BackgroundColor="Purple"
+                        TextColor="White"/>
+                
                 <CollectionView ItemsSource="{Binding Categories}">
                     <CollectionView.ItemTemplate>
                         <DataTemplate>


### PR DESCRIPTION
## Summary by Sourcery

Enable role-based permissions by saving user credentials and context, adapting navigation and court form behavior for Admin vs User roles, and cleaning up obsolete token handling logic

New Features:
- Persist preferred_username from token and derive islander, EDS, and business context into preferences after login
- Introduce UserRole/IsUserRole flags and DestroyInstance method in CourtService to control role-based behavior and reset state
- Add NavigateToCourtCommand and hide navigation categories for islander (User) role
- Automatically assign business, EDS, and islander IDs for 'User' role when sending court data

Enhancements:
- Update CourtService and CourtPostView to bypass selection and validation logic based on user role
- Conditionally show or hide the Business picker and related UI validations in the court entry form for Admin only
- Refine available hoses, new sale, and additional info toggles to honor user permissions

Chores:
- Remove commented-out token splitting and unused config parsing code