### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Override TargetFrameworks for Android build
         run: |
-          echo '<Project><PropertyGroup><TargetFramework>net8.0-android</TargetFramework></PropertyGroup></Project>' > Directory.Build.props
+          echo '<Project><PropertyGroup><TargetFramework>net8.0-android</TargetFramework></PropertyGroup></Project>' > $GITHUB_WORKSPACE/Directory.Build.props
 
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v3


### PR DESCRIPTION
Prueba de solucion para que no compile para IOS en el paso para ANDROID

## Summary by Sourcery

CI:
- Use $GITHUB_WORKSPACE when generating Directory.Build.props to correctly override the target framework in the Android job