### PR TITLE
add OnAppearing

### DIFF
--- a/APP.Eds/APP.Eds/UsesCases/Inventory/InventoryPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Inventory/InventoryPostView.xaml.cs
@@ -15,6 +15,14 @@ namespace APP.Eds.UsesCases.Inventory
             ViewModel = new InventoryViewModel();
             BindingContext = ViewModel;
         }
+
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            if (ViewModel != null)
+                await ViewModel.LoadDataAsync();
+        }
+
     }
 
 }

--- a/APP.Eds/APP.Eds/UsesCases/Inventory/InventoryViewModel.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Inventory/InventoryViewModel.cs
@@ -45,8 +45,6 @@ namespace APP.Eds.UsesCases.Inventory
                 if (c != null)
                     c.IsExpanded = !c.IsExpanded;
             });
-
-            Task.Run(async () => await LoadDataAsync());
         }
 
         public async Task LoadDataAsync()


### PR DESCRIPTION
## Summary by Sourcery

Trigger inventory data loading when the view appears instead of during ViewModel construction

Enhancements:
- Add an OnAppearing override in InventoryPostView to call LoadDataAsync on page appearance
- Remove the Task.Run call that loaded data in the InventoryViewModel constructor