### PR TITLE
Fix empty list and errors in CourtPostView and popups

### DIFF
--- a/APP.Eds/APP.Eds/Components/PopUp/AddCourtExpenditure.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddCourtExpenditure.xaml
@@ -49,7 +49,7 @@
                         <Grid RowDefinitions="*,*" ColumnDefinitions="*,*,*">
                             <Label Text="{Binding  AmountTranslation}" VerticalOptions="Center" HorizontalOptions="Center" Grid.Row="0" Grid.Column="1"/>
                             <Entry x:Name="FirstEntry" Placeholder="Ingrese monto" Grid.Row="1" Grid.Column="1"
-                                   Text="{Binding CourtExpenditureAmount, StringFormat='{0:N0}', Mode=TwoWay}"
+                                   Text="{Binding CourtExpenditureAmount, Mode=TwoWay}"
                                    Completed="EntryAmountCompleted" TextChanged="FirstEntry_TextChanged"
                                    IsEnabled="False" Keyboard="Numeric" HorizontalTextAlignment="Center"
                                    AutomationId="AmountEntry"/>

--- a/APP.Eds/APP.Eds/Components/PopUp/AddCourtTypeOfCollection.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddCourtTypeOfCollection.xaml
@@ -32,9 +32,7 @@
             <!--  Campos de Entrada  -->
             <ScrollView Grid.Row="1">
                 <VerticalStackLayout Padding="0,10">
-                <Frame Padding="10"
-                       CornerRadius="10"
-                       Margin="0,0,0,10"
+                <Frame Padding="10" CornerRadius="10" Margin="0,0,0,10"
                        AutomationId="FrameTypeOfCollection">
                     <Grid RowDefinitions="*,*" ColumnDefinitions="*,*,*">
                             <Label Text="{Binding TypeofCollectionTranslation}" VerticalOptions="Center" HorizontalOptions="Center" Grid.Row="0" Grid.Column="1" AutomationId="LabelTypeofCollectionTranslation"/>
@@ -45,14 +43,12 @@
                                 AutomationId="PickerTypeOfCollection"/>
                     </Grid>
                 </Frame>
-                <Frame Padding="10"
-                       CornerRadius="10"
-                       Margin="0,0,0,10"
+                <Frame Padding="10" CornerRadius="10" Margin="0,0,0,10"
                        AutomationId="FrameCollectionAmount">
                     <Grid RowDefinitions="*,*" ColumnDefinitions="*,*,*">
                             <Label Text="{Binding CollectionAmount}" VerticalOptions="Center" HorizontalOptions="Center" Grid.Row="0" Grid.Column="1" AutomationId="LabelCollectionAmount"/>
                             <Entry x:Name="FirstEntry"   Placeholder="Ingrese el monto" Grid.Row="1" Grid.Column="1"
-                               Text="{Binding CourtTypeOfCollectionAmount,Mode=TwoWay, StringFormat='{0:N0}'}"
+                               Text="{Binding CourtTypeOfCollectionAmount,Mode=TwoWay}"
                                Completed="EntryAmountCompleted" TextChanged="FirstEntry_TextChanged"
                                IsEnabled="False" Keyboard="Numeric" HorizontalTextAlignment="Center"
                                AutomationId="EntryCourtTypeOfCollectionAmount"/>

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
@@ -55,19 +55,17 @@
                             <BoxView x:Name="AmountBoxView" BackgroundColor="Transparent" Color="Transparent" CornerRadius="5" Grid.Row="2" Grid.Column="2"/>
                             <Entry x:Name="FirstEntry" AutomationId="AccumulatedAmountEntry"
                                    Keyboard="Numeric" Placeholder="Ingrese el monto"
-                                   Text="{Binding AccumulatedAmount, Mode=TwoWay, StringFormat='{0:N0}'}"
+                                   Text="{Binding AccumulatedAmount, Mode=TwoWay}"
                                    Margin="2" Grid.Row="2" Grid.Column="2"
                                    Unfocused="OnEntryUnfocused" Completed="EntryAccumulatedCompleted"
                                    IsEnabled="False"/>
 
-                            <Label Text="Amount" HorizontalOptions="End" Grid.Row="3" Grid.Column="0"/>
+                            <Label Text="Venta en dinero" HorizontalOptions="End" Grid.Row="3" Grid.Column="0"/>
                             <Label Text="{Binding AmountDifferenceResult, StringFormat=' $ {0:N0}'}" VerticalOptions="Center" HorizontalOptions="Start" Grid.Row="3" Grid.Column="2"/>
                         </Grid>
                         
                     </Frame>
-                    <Frame Padding="10"
-                           CornerRadius="10"
-                           HasShadow="True">
+                    <Frame Padding="10" CornerRadius="10" HasShadow="True">
                         <Grid RowDefinitions="*,*,*" ColumnDefinitions="*,20,*" RowSpacing="5">
                             <Label Text="{Binding LastAccumulatedGallonsTranslation}" VerticalOptions="Center" HorizontalOptions="End" Grid.Row="0" Grid.Column="0"/>
                             <Label Text="{Binding LastAccumulatedGallons, StringFormat='  {0:N2}'}" VerticalOptions="Center" Grid.Row="0" Grid.Column="2"/>
@@ -78,10 +76,10 @@
                                    Keyboard="Numeric" Placeholder="Ingrese los galones"
                                    Text="{Binding AccumulatedGallons, Mode=TwoWay}"
                                    Margin="2" Grid.Row="1" Grid.Column="2"
-                                   Unfocused="OnEntryUnfocused" Completed="EntryGallonsCompleted"
+                                   Completed="EntryGallonsCompleted"
                                    IsEnabled="False"/>
 
-                            <Label Text="Gallons " VerticalOptions="Center" HorizontalOptions="End" Grid.Row="2" Grid.Column="0"/>
+                            <Label Text="Venta en galones" VerticalOptions="Center" HorizontalOptions="End" Grid.Row="2" Grid.Column="0"/>
                             <Label Text="{Binding GallonsDifferenceResult, StringFormat='  {0:N2}'}" VerticalOptions="Center" HorizontalOptions="Start" Grid.Row="2" Grid.Column="2"/>
 
                             <Button Text="✎"

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
@@ -1,4 +1,6 @@
-﻿using APP.Eds.Services.Court;
+﻿using System.Diagnostics;
+using System.Globalization;
+using APP.Eds.Services.Court;
 using CommunityToolkit.Maui.Views;
 
 namespace APP.Eds.Components.PopUp;
@@ -87,25 +89,30 @@ public partial class AddDispenser : Popup
 
     private void EntryAccumulatedCompleted(object sender, EventArgs e)
     {
-        if (BindingContext is CourtService vm)
-        {   
-            if (vm.AccumulatedAmount > vm.LastAccumulatedAmount)
-            {
-                vm.AccumulatedGallons = Math.Round(vm.LastAccumulatedGallons + (vm.AmountDifferenceResult / vm.SelectedHose.Price),2);
-            }
-            AmountBoxView.Color = vm.AccumulatedAmount >= vm.LastAccumulatedAmount ? Colors.Green : Colors.Red;
-            GallonBoxView.Color = vm.AccumulatedGallons >= vm.LastAccumulatedGallons ? Colors.Green : Colors.Red;
-        }
+        UpdateAccumulatedValues();
     }
    
     private void OnEntryUnfocused(object sender, FocusEventArgs e)
+    {
+        UpdateAccumulatedValues();
+    }
+
+    private void UpdateAccumulatedValues()
     {
         if (BindingContext is CourtService vm)
         {
             if (vm.AccumulatedAmount > vm.LastAccumulatedAmount)
             {
-                vm.AccumulatedGallons = Math.Round(vm.LastAccumulatedGallons + (vm.AmountDifferenceResult / vm.SelectedHose.Price),2);
+                vm.AccumulatedGallons = Math.Round(vm.LastAccumulatedGallons + (vm.AmountDifferenceResult / vm.SelectedHose.Price), 2);
             }
+            UpdateAccumulatedColors();
+        }
+    }
+
+    private void UpdateAccumulatedColors()
+    {
+        if (BindingContext is CourtService vm)
+        {
             AmountBoxView.Color = vm.AccumulatedAmount >= vm.LastAccumulatedAmount ? Colors.Green : Colors.Red;
             GallonBoxView.Color = vm.AccumulatedGallons >= vm.LastAccumulatedGallons ? Colors.Green : Colors.Red;
         }
@@ -114,12 +121,8 @@ public partial class AddDispenser : Popup
 
     private void EntryGallonsCompleted(object sender, EventArgs e)
     {
-        if (BindingContext is CourtService vm)
-        {
-            AmountBoxView.Color = vm.AccumulatedAmount >= vm.LastAccumulatedAmount ? Colors.Green : Colors.Red;
-            GallonBoxView.Color = vm.AccumulatedGallons >= vm.LastAccumulatedGallons ? Colors.Green : Colors.Red;
-            AddButton.Focus();
-        }
+        UpdateAccumulatedColors();
+        AddButton.Focus();
     }
 
     private void HoseSelected(object sender, EventArgs e)
@@ -130,7 +133,6 @@ public partial class AddDispenser : Popup
             FirstEntry.Focus();
             FirstEntry.CursorPosition = FirstEntry.Text.Length;
 
-            // Mostrar el precio directamente desde el modelo seleccionado
             if (BindingContext is CourtService vm && vm.SelectedHose is not null)
             {
                 double price = vm.SelectedHose.Price;

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDocuemt.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDocuemt.xaml
@@ -19,7 +19,7 @@
 
             <!--  Encabezado  -->
             <Grid Grid.Row="0" ColumnDefinitions="*, Auto, *" Padding="0,0,0,10">
-                <Label Grid.Column="1" FontAttributes="Bold" FontSize="22" Text="AddDocumentTranslation" HorizontalTextAlignment="Center" HorizontalOptions="Center" VerticalOptions="Center"/>
+                <Label Grid.Column="1" FontAttributes="Bold" FontSize="22" Text="Agregar comprobante" HorizontalTextAlignment="Center" HorizontalOptions="Center" VerticalOptions="Center"/>
                 <Button Grid.Column="2"
                         BackgroundColor="Transparent"
                         Clicked="OnCloseTapped"
@@ -41,11 +41,11 @@
 						Clicked="OnSelectFileClicked"
                         AutomationId="SelectFileButton"
 						CornerRadius="10"
-						Text="Select File"/>
+						Text="Seleccionar archivo"/>
 					<Label
 						FontAttributes="Bold"
 						IsVisible="{Binding IsFileSelected}"
-						Text="Selected File:"
+						Text="Archivo seleccionado:"
                         AutomationId="SelectedFileLabel"/>
 					<Label
 						FontAttributes="Italic"
@@ -62,7 +62,7 @@
                     AutomationId="AddButton"
                     CornerRadius="10"
                     FontSize="18"
-                    Text="Add"
+                    Text="Agregar"
                     TextColor="White"
                     VerticalOptions="Center"
                     HeightRequest="40"/>

--- a/APP.Eds/APP.Eds/Components/PopUp/Category.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/Category.xaml
@@ -28,14 +28,12 @@
                        HorizontalOptions="Center" VerticalOptions="Center"
                        AutomationId="LabelCategoryTitle"/>
 
-                <button:HoverButtonPopup
-                        Grid.Column="2"                      
+                <Button Grid.Column="2"                      
                         Clicked="OnCloseTapped"
-                        FontSize="20" Text="✖"
+                        FontSize="20" Text="✖" TextColor="#6200E8"
                         WidthRequest="25" HeightRequest="25" Padding="-10"
-                        HorizontalOptions="End" VerticalOptions="Center"
-                        HoverColorPopup="Gray"
-                        Margin="0,0,0,0"
+                        HorizontalOptions="End" VerticalOptions="Center" Margin="0,0,0,0"
+                        BackgroundColor="Transparent"
                         AutomationId="ButtonClosePopup"/>
             </Grid>
             
@@ -52,8 +50,6 @@
                             Text="{Binding Name}" 
                             Command="{Binding NavigateCommand}" 
                             Margin="0,0,0,10"
-                            HoverColorPopup="DarkGray"
-                            PressedColorPopup="Black"
                             Clicked="OnMenuItemClicked"
                             Padding="10,5,10,10"
                             AutomationId="ButtonMenuItem"/>

--- a/APP.Eds/APP.Eds/Controls/HoverButton.cs
+++ b/APP.Eds/APP.Eds/Controls/HoverButton.cs
@@ -77,12 +77,13 @@ namespace APP.Eds.Controls
 
     public class HoverButtonPopup : MauiButton
     {
-        public Color NormalColorPopup { get; set; } = Colors.Gray;
+        //public Color NormalColorPopup { get; set; } = Colors.Gray;
+        private Color? _originalBackgroundColor;
         public Color PressedColorPopup { get; set; } = Colors.Black;
         public Color HoverColorPopup { get; set; } = Colors.Black;
         public HoverButtonPopup()
         {
-            BackgroundColor = NormalColorPopup;
+            //BackgroundColor = NormalColorPopup;
 
             Pressed += OnPressedPopup;
             Released += OnReleasedPopup;
@@ -96,11 +97,12 @@ namespace APP.Eds.Controls
 
         private async void OnReleasedPopup(object sender, EventArgs e)
         {
-            _ = AnimateColorAsync(NormalColorPopup);
+            _ = AnimateColorAsync(_originalBackgroundColor);
         }
 
         private async void OnPressedPopup(object sender, EventArgs e)
         {
+            SaveOriginalColor();
             _ = AnimateColorAsync(PressedColorPopup);
         }
 
@@ -112,9 +114,16 @@ namespace APP.Eds.Controls
 
         private async void OnPointerExited(object sender, EventArgs e)
         {
-            _ = AnimateColorAsync(NormalColorPopup);
+            SaveOriginalColor();
+            _ = AnimateColorAsync(_originalBackgroundColor);
         }
 #endif
+
+        private void SaveOriginalColor()
+        {
+            if (_originalBackgroundColor == null)
+                _originalBackgroundColor = BackgroundColor;
+        }
 
         private async Task AnimateColorAsync(Color targetColor)
         {

--- a/APP.Eds/APP.Eds/Models/Provider/ProviderApiResponse.cs
+++ b/APP.Eds/APP.Eds/Models/Provider/ProviderApiResponse.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.Json.Serialization;
+
+namespace APP.Eds.Models.Provider;
+public class ProviderApiResponse
+{
+    [JsonPropertyName("statusCode")]
+    public int StatusCode { get; set; }
+
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("message")]
+    public string Message { get; set; }
+
+    [JsonPropertyName("data")]
+    public List<ProviderResponse> Data { get; set; }
+}

--- a/APP.Eds/APP.Eds/Models/Provider/ProviderResponse.cs
+++ b/APP.Eds/APP.Eds/Models/Provider/ProviderResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Text.Json.Serialization;
+
+namespace APP.Eds.Models.Provider;
+public class ProviderResponse
+{
+    [JsonPropertyName("idProvider")]
+    public int IdProvider { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+}

--- a/APP.Eds/APP.Eds/Resources/Styles/Colors.xaml
+++ b/APP.Eds/APP.Eds/Resources/Styles/Colors.xaml
@@ -19,6 +19,7 @@
     <Color x:Key="MidnightBlue">#190649</Color>
     <Color x:Key="OffBlack">#1f1f1f</Color>
 
+    <Color x:Key="Gray50">#F5F5F5</Color>
     <Color x:Key="Gray100">#E1E1E1</Color>
     <Color x:Key="Gray200">#C8C8C8</Color>
     <Color x:Key="Gray300">#ACACAC</Color>

--- a/APP.Eds/APP.Eds/Resources/Styles/Styles.xaml
+++ b/APP.Eds/APP.Eds/Resources/Styles/Styles.xaml
@@ -2,7 +2,8 @@
 <?xaml-comp compile="true" ?>
 <ResourceDictionary 
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:APP.Eds.Controls">
 
     <Style TargetType="ActivityIndicator">
         <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
@@ -14,18 +15,44 @@
     </Style>
 
     <Style TargetType="Border">
-        <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
+        <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray500}}" />
         <Setter Property="StrokeShape" Value="Rectangle"/>
         <Setter Property="StrokeThickness" Value="1"/>
     </Style>
 
     <Style TargetType="BoxView">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}" />
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray50}, Dark={StaticResource Gray900}}" />
     </Style>
 
     <Style TargetType="Button">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource PrimaryDarkText}}" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource White}}" />
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource Tertiary}}" />
+        <Setter Property="FontFamily" Value="OpenSansRegular"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="BorderWidth" Value="0"/>
+        <Setter Property="CornerRadius" Value="8"/>
+        <Setter Property="Padding" Value="14,10"/>
+        <Setter Property="MinimumHeightRequest" Value="44"/>
+        <Setter Property="MinimumWidthRequest" Value="44"/>
+        <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal" />
+                    <VisualState x:Name="Disabled">
+                        <VisualState.Setters>
+                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}" />
+                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="PointerOver" />
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
+    </Style>
+
+    <Style TargetType="local:HoverButtonPopup">
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource White}}" />
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource Tertiary}}" />
         <Setter Property="FontFamily" Value="OpenSansRegular"/>
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="BorderWidth" Value="0"/>
@@ -68,7 +95,7 @@
     </Style>
 
     <Style TargetType="DatePicker">
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
         <Setter Property="FontFamily" Value="OpenSansRegular"/>
         <Setter Property="FontSize" Value="15"/>

--- a/APP.Eds/APP.Eds/Services/Compartiment/CompartimentService.cs
+++ b/APP.Eds/APP.Eds/Services/Compartiment/CompartimentService.cs
@@ -18,6 +18,8 @@ namespace APP.Eds.Services.Compartiment
         public ObservableCollection<TankResponse> TankList { get; set; } = [];
         public ObservableCollection<CompartimentResponse> CompartimentList { get; set; } = [];
         private CompartimentRequest Request { get; set; }
+
+
         private CompartimentModel _compartiment;
         public CompartimentModel Compartiment
         {
@@ -261,6 +263,7 @@ namespace APP.Eds.Services.Compartiment
         {
             _authToken = TokenHelper.LoadToken(Configuration.KeycloakCliendId, Configuration.KeycloakRealms);
             GetAllTankData();
+            GetCompartimentAsync();
             GetByIdCompartimentDataCommand = new Command<int>(async (CompartimentId) => await GetByIdCompartimentDataAsync(CompartimentId));
             SaveCompartimentDataCommand = new Command(async () => await SaveCompartimentDataAsync());
             LoadTranslationsAsync();
@@ -371,7 +374,7 @@ namespace APP.Eds.Services.Compartiment
             {
                 using var httpClient = new HttpClient();
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
-                var response = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/compartiment");
+                var response = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/compartiment?PageNumber=1&PageSize=100");
                 var compartiments = JsonSerializer.Deserialize<CompartimentApiResponse>(response, new JsonSerializerOptions
                 {
                     PropertyNamingPolicy = JsonNamingPolicy.CamelCase

--- a/APP.Eds/APP.Eds/Services/Provider/ProviderService.cs
+++ b/APP.Eds/APP.Eds/Services/Provider/ProviderService.cs
@@ -1,11 +1,12 @@
-﻿using APP.Eds.Models.Provider;
+﻿using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Text.Json;
-using System.Text;
-using System.Windows.Input;
-using APP.Eds.Services.Config;
-using APP.Eds.Helpers;
 using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Windows.Input;
+using APP.Eds.Helpers;
+using APP.Eds.Models.Provider;
+using APP.Eds.Services.Config;
 
 namespace APP.Eds.Services.Provider;
 
@@ -14,6 +15,7 @@ public class ProviderService : INotifyPropertyChanged
     public event PropertyChangedEventHandler? PropertyChanged;
     private ProviderRequest Request { get; set; }
     private ProviderModel _provider;
+    public ObservableCollection<ProviderResponse> ProviderList { get; set; } = [];
     private string? _authToken;
     public ProviderModel Provider
     {
@@ -44,6 +46,7 @@ public class ProviderService : INotifyPropertyChanged
         GetByIdProviderDataCommand = new Command<int>(async (providerId) => await GetByIdProviderDataAsync(providerId));
         SaveProviderDataCommand = new Command(async () => await SaveProviderDataAsync());
         _authToken = TokenHelper.LoadToken(Configuration.KeycloakCliendId, Configuration.KeycloakRealms);
+        GetProvidersAsync();
     }
 
     public async Task GetByIdProviderDataAsync(int providerId)
@@ -109,6 +112,36 @@ public class ProviderService : INotifyPropertyChanged
         catch (Exception ex)
         {
             await Application.Current.MainPage.DisplayAlert("Error", $"Error al enviar los datos: {ex.Message}", "OK");
+        }
+    }
+
+    public async Task GetProvidersAsync()
+    {
+        if (string.IsNullOrEmpty(_authToken))
+        {
+            await Application.Current.MainPage.DisplayAlert("Error", "No se encontró el token de autenticación", "OK");
+            return;
+        }
+        try
+        {
+            using var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
+            var response = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/provider?PageNumber=1&PageSize=100");
+            Console.WriteLine(response);
+            var providers = JsonSerializer.Deserialize<ProviderApiResponse>(response, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            });
+
+            ProviderList.Clear();
+            foreach (var provider in providers.Data)
+            {
+                ProviderList.Add(provider);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error: {ex.Message}");
         }
     }
 

--- a/APP.Eds/APP.Eds/UsesCases/Compartiment/CompartimentPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Compartiment/CompartimentPostView.xaml
@@ -5,7 +5,7 @@
              xmlns:controls="clr-namespace:APP.Eds.UsesCases.LoadingView"
              Title="{Binding CompartimentManagement}">
 
-    <Grid>
+    
         <ScrollView>
             <VerticalStackLayout Padding="20" Spacing="15">
                 <Label FontSize="16" Text="Numero"/>
@@ -23,51 +23,47 @@
                 <Label FontSize="16" Text="Altura"/>
                 <Entry Keyboard="Numeric" Placeholder="{Binding EnterHeight}" Text="{Binding Height, Mode=TwoWay}" TextChanged="NumericEntry_TextChanged" AutomationId="EntryCompartimentHeight"/>
 
-                <Picker Title="{Binding SelectTank}"
-                        ItemsSource="{Binding TankList}"
-                        ItemDisplayBinding="{Binding Number}"
-                        SelectedItem="{Binding SelectedTank, Mode=TwoWay}"
-                        AutomationId="PickerTank"/>
+                <Picker Title="{Binding SelectTank}" ItemsSource="{Binding TankList}" ItemDisplayBinding="{Binding Number}" SelectedItem="{Binding SelectedTank, Mode=TwoWay}" AutomationId="PickerTank"/>
 
-                <Button BackgroundColor="Green"
-                        Clicked="Button_Clicked_1"
-                        CornerRadius="10"
-                        Text="{Binding SendData}"
-                        TextColor="White"
+                <Button BackgroundColor="Green" Clicked="Button_Clicked_1"
+                        Text="{Binding SendData}" TextColor="White" CornerRadius="10"
                         AutomationId="ButtonSendCompartimentData"/>
 
-                <Label FontSize="18" Text="{Binding ListDispensers}"/>
-
-                <CollectionView ItemsSource="{Binding DispenserList}" Margin="0,20"
-                                HeightRequest="400">
+                <CollectionView ItemsSource="{Binding CompartimentList}" Margin="0,20,0,0">
                     <CollectionView.ItemTemplate>
                         <DataTemplate>
-                            <Grid Padding="10">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                <Label Text="{Binding Id}" FontSize="14" Grid.Row="0" />
-                                <Label Text="{Binding Number}" FontSize="14" Grid.Row="1" />
-                                <Label Text="{Binding Nominal}" FontSize="14" Grid.Row="2" />
-                                <Label Text="{Binding Operative}" FontSize="14" Grid.Row="3" />
-                                <Label Text="{Binding Stock}" FontSize="14" Grid.Row="4" />
-                                <Label Text="{Binding Height}" FontSize="14" Grid.Row="5" />
-                                <Label Text="{Binding IdTank}" FontSize="14" Grid.Row="6" />
-                            </Grid>
+                            <VerticalStackLayout>
+                                <Label Text="{Binding Number,StringFormat='Compartimiento {0:N0}'}" FontSize="16" Grid.Row="1" Grid.Column="3" HorizontalOptions="Center" Margin="0,20,0,5"/>
+                                <Frame Padding="0">
+                                    <Grid ColumnDefinitions="20,*,20,*,10" RowDefinitions="10,*,*,*,*,*,*,*,*,10">
+                                        <!--<Label Text="{Binding Number, StringFormat='Compartimiento {0:N0}'}" FontSize="16" Grid.Row="1" Grid.ColumnSpan="5" HorizontalOptions="Center"/>-->
+
+                                        <Label Text="Capacidad nominal"  Grid.Row="3" Grid.Column="1"/>
+                                        <Label Text="{Binding Nominal}"  Grid.Row="3" Grid.Column="3"/>
+
+                                        <Label Text="Capacidad operativa"  Grid.Row="4" Grid.Column="1"/>
+                                        <Label Text="{Binding Operative}"  Grid.Row="4" Grid.Column="3"/>
+                                        <BoxView Grid.Row="4" Grid.ColumnSpan="5" ZIndex="-1"/>
+
+                                        <Label Text="Stock"  Grid.Row="5" Grid.Column="1"/>
+                                    <Label Text="{Binding Stock, StringFormat='{0:N2}'}"  Grid.Row="5" Grid.Column="3"/>
+
+                                        <Label Text="Altura"  Grid.Row="6" Grid.Column="1"/>
+                                        <Label Text="{Binding Height}"  Grid.Row="6" Grid.Column="3"/>
+                                        <BoxView Grid.Row="6" Grid.ColumnSpan="5" ZIndex="-1"/>
+
+                                        <Label Text="Tanque"  Grid.Row="7" Grid.Column="1"/>
+                                        <Label Text="{Binding IdTank}"  Grid.Row="7" Grid.Column="3"/>
+                                        
+                                    </Grid>
+                                </Frame>
+                            </VerticalStackLayout>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
                 </CollectionView>
-            </VerticalStackLayout>
-        </ScrollView>
 
         <controls:LoadingView x:Name="LoadingOverlay"
-                              IsVisible="{Binding IsLoading}" VerticalOptions="FillAndExpand"
-                              HorizontalOptions="FillAndExpand" />
-    </Grid>
+                              IsVisible="{Binding IsLoading}"/>
+        </VerticalStackLayout>
+    </ScrollView>
 </ContentPage>

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
@@ -61,7 +61,7 @@
                         CornerRadius="10">
                     <VerticalStackLayout Spacing="10">
                         <Label FontAttributes="Bold" FontSize="18" Text="{Binding CashCount}" HorizontalOptions="Center"/>
-                        <Grid RowDefinitions="20,20,20,20,20,*" ColumnDefinitions="20,*,*,20" RowSpacing="10">
+                        <Grid RowDefinitions="*,*,*,*,*,*" ColumnDefinitions="20,*,*,20" RowSpacing="15">
                             <Label Text="{Binding SalesInMoney}" FontAttributes="Bold" Grid.Row="0" Grid.Column="1" HorizontalOptions="Center"/>
                             <Label Text="{Binding TotalAmount, StringFormat='$ {0:N0}'}" Grid.Row="1" Grid.Column="1" HorizontalOptions="Center" />
 
@@ -110,19 +110,27 @@
                     <CollectionView.ItemTemplate>
                         <DataTemplate>
                             <Frame Margin="5" Padding="10" BorderColor="LightGray" CornerRadius="8">
-                                <Grid ColumnDefinitions="Auto,20,*,Auto" RowDefinitions="Auto,Auto,Auto" RowSpacing="5">
-                                    <Label Text="Number" FontAttributes="Bold" Grid.Row="0" Grid.Column="0"/>
+                                <Grid ColumnDefinitions="Auto,20,*,Auto" RowDefinitions="*,*,*,*,*" RowSpacing="5">
+                                    <Label Text="Manguera #" FontAttributes="Bold" Grid.Row="0" Grid.Column="0"/>
                                     <Label Text="{Binding NumberName}" Grid.Row="0" Grid.Column="2"/>
+                                    <BoxView Grid.Row="1" Grid.ColumnSpan="4" ZIndex="-1"/>
 
-                                    <Label Text="Accumulated Amount" FontAttributes="Bold" Grid.Row="1" Grid.Column="0"/>
+                                    <Label Text="Monto acumulado" FontAttributes="Bold" Grid.Row="1" Grid.Column="0"/>
                                     <Label Text="{Binding AccumulatedAmount, StringFormat='$ {0:N0}'}" Grid.Row="1" Grid.Column="2"/>
 
-                                    <Label Text="Gallons Accumulated" FontAttributes="Bold" Grid.Row="2" Grid.Column="0"/>
-                                    <Label Text="{Binding AccumulatedGallons, StringFormat='{0:N2}'}" Grid.Row="2" Grid.Column="2"/>
+                                    <Label Text="Venta en dinero" FontAttributes="Bold" Grid.Row="2" Grid.Column="0"/>
+                                    <Label Text="{Binding AmountDifferenceResult, StringFormat='$ {0:N0}'}" Grid.Row="2" Grid.Column="2"/>
+                                    <BoxView Grid.Row="3" Grid.ColumnSpan="4" ZIndex="-1"/>
+
+                                    <Label Text="Galones acumulados" FontAttributes="Bold" Grid.Row="3" Grid.Column="0"/>
+                                    <Label Text="{Binding AccumulatedGallons, StringFormat='{0:N2}'}" Grid.Row="3" Grid.Column="2"/>
+
+                                    <Label Text="Venta en galones" FontAttributes="Bold" Grid.Row="4" Grid.Column="0"/>
+                                    <Label Text="{Binding GallonsDifferenceResult, StringFormat='{0:N2}'}" Grid.Row="4" Grid.Column="2"/>
 
                                     <Button Text="X" 
                                         AutomationId="DeleteDispenserButton"
-                                        Grid.Column="3" Grid.RowSpan="3"
+                                        Grid.Column="3" Grid.RowSpan="5"
                                         WidthRequest="50" HeightRequest="50"
                                         BackgroundColor="Transparent"
                                         TextColor="#6A1B9A"
@@ -140,23 +148,23 @@
                 <Grid ColumnDefinitions="*, Auto"  x:Name="TypesofAggregateCollections">
                     <Label  Text="{Binding TypesofAggregateCollections}" FontAttributes="Bold" FontSize="18" Grid.ColumnSpan="2" VerticalOptions="Center" HorizontalOptions="Center"/>
                     <Button Text="💬"
-             Command="{Binding HideCollectionList}"
-             AutomationId="HideCollectionListButton"
-             WidthRequest="46"  HeightRequest="46" 
-             BackgroundColor="Transparent"
-             HorizontalOptions="End"
-             Grid.Column="1">
+                            Command="{Binding HideCollectionList}"
+                            AutomationId="HideCollectionListButton"
+                            WidthRequest="46"  HeightRequest="46" 
+                            BackgroundColor="Transparent"
+                            HorizontalOptions="End"
+                            Grid.Column="1">
                         <Button.Triggers>
                             <DataTrigger
-                 TargetType="Button"
-                 Binding="{Binding VisibleReceipts}"
-                 Value="True">
+                                TargetType="Button"
+                                Binding="{Binding VisibleReceipts}"
+                                Value="True">
                                 <Setter Property="Text" Value="➖" />
                             </DataTrigger>
                             <DataTrigger
-                 TargetType="Button"
-                 Binding="{Binding VisibleReceipts}"
-                 Value="False">
+                                TargetType="Button"
+                                Binding="{Binding VisibleReceipts}"
+                                Value="False">
                                 <Setter Property="Text" Value="👁️" />
                             </DataTrigger>
                         </Button.Triggers>
@@ -168,25 +176,25 @@
                         <DataTemplate>
                             <Frame Margin="5" Padding="10" BorderColor="LightGray" CornerRadius="8">
                                 <Grid ColumnDefinitions="Auto,20,*,Auto" RowDefinitions="Auto, Auto, Auto" RowSpacing="5">
-                                    <Label Text="TypeofCollection" FontAttributes="Bold" Grid.Row="0" Grid.Column="0"/>
+                                    <Label Text="Tipo de cobro" FontAttributes="Bold" Grid.Row="0" Grid.Column="0"/>
                                     <Label Text="{Binding TypeOfCollectionName}" Grid.Row="0" Grid.Column="2"/>
 
-                                    <Label Text="Amount" FontAttributes="Bold" Grid.Row="1" Grid.Column="0"/>
+                                    <Label Text="Monto" FontAttributes="Bold" Grid.Row="1" Grid.Column="0"/>
                                     <Label Text="{Binding Amount, StringFormat='$ {0:N0}'}" Grid.Row="1" Grid.Column="2"/>
 
-                                    <Label Text="Description" FontAttributes="Bold" Grid.Row="2" Grid.Column="0"/>
+                                    <Label Text="Descricion" FontAttributes="Bold" Grid.Row="2" Grid.Column="0"/>
                                     <Label Text="{Binding Description}" Grid.Row="2" Grid.Column="2"/>
 
-                                    <Button Text="X" 
-                         AutomationId="DeleteCollectionButton"
-                         Grid.Column="3" Grid.RowSpan="3"
-                         WidthRequest="50" HeightRequest="50"
-                         BackgroundColor="Transparent"
-                         TextColor="#6A1B9A"
-                         CornerRadius="0"
-                         VerticalOptions="Center"
-                         Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.DeleteCollectionCommand}"
-                         CommandParameter="{Binding .}"/>
+                                    <Button Text="X"
+                                            AutomationId="DeleteCollectionButton"
+                                            Grid.Column="3" Grid.RowSpan="3"
+                                            WidthRequest="50" HeightRequest="50"
+                                            BackgroundColor="Transparent"
+                                            TextColor="#6A1B9A"
+                                            CornerRadius="0"
+                                            VerticalOptions="Center"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.DeleteCollectionCommand}"
+                                            CommandParameter="{Binding .}"/>
                                 </Grid>
                             </Frame>
                         </DataTemplate>
@@ -195,7 +203,7 @@
 
                 <!-- Documents con botón de eliminar -->
                 <Grid ColumnDefinitions="*, Auto" x:Name="AddedDocuments">
-                    <Label Text="AddedDocuments" FontAttributes="Bold" FontSize="18" Grid.ColumnSpan="2" VerticalOptions="Center" HorizontalOptions="Center"/>
+                    <Label Text="Comprobantes" FontAttributes="Bold" FontSize="18" Grid.ColumnSpan="2" VerticalOptions="Center" HorizontalOptions="Center"/>
                     <Button  Text="�️"
                              Command="{Binding HideDocumentList}"
                              AutomationId="HideDocumentListButton"
@@ -224,7 +232,7 @@
                         <DataTemplate>
                             <Frame Margin="0,5" Padding="10" BorderColor="LightGray" CornerRadius="8">
                                 <Grid ColumnDefinitions="*, *, *, Auto" RowDefinitions="Auto, Auto">
-                                    <Label Grid.Row="1" Grid.Column="0" Text="Document" FontAttributes="Bold"/>
+                                    <Label Grid.Row="1" Grid.Column="0" Text="Comprobante" FontAttributes="Bold"/>
                                     <Label Grid.Row="1" Grid.Column="1" Text="{Binding DocumentName}"/>
 
                                     <Button Text="X" 
@@ -275,13 +283,13 @@
                         <DataTemplate>
                             <Frame Margin="5" Padding="10" BorderColor="LightGray" CornerRadius="8">
                                 <Grid ColumnDefinitions="Auto,20,*,Auto" RowDefinitions="Auto, Auto, Auto" RowSpacing="5">
-                                    <Label Text="Expenditures" FontAttributes="Bold" Grid.Row="0" Grid.Column="0"/>
+                                    <Label Text="Tipo de gasto" FontAttributes="Bold" Grid.Row="0" Grid.Column="0"/>
                                     <Label Text="{Binding ExpenditureName}" Grid.Row="0" Grid.Column="2"/>
 
-                                    <Label Text="Amount" FontAttributes="Bold" Grid.Row="1" Grid.Column="0"/>
+                                    <Label Text="Monto" FontAttributes="Bold" Grid.Row="1" Grid.Column="0"/>
                                     <Label Text="{Binding Amount, StringFormat='$ {0:N0}'}" Grid.Row="1" Grid.Column="2"/>
 
-                                    <Label Text="Description" FontAttributes="Bold" Grid.Row="2" Grid.Column="0"/>
+                                    <Label Text="Descricion" FontAttributes="Bold" Grid.Row="2" Grid.Column="0"/>
                                     <Label Text="{Binding Description}" Grid.Row="2" Grid.Column="2"/>
 
                                     <Button Text="X" 

--- a/APP.Eds/APP.Eds/UsesCases/Provider/ProviderPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Provider/ProviderPostView.xaml
@@ -5,24 +5,37 @@
              xmlns:controls="clr-namespace:APP.Eds.UsesCases.LoadingView"
              Title="Gestion De Proveedor">
     <AbsoluteLayout>
-        <VerticalStackLayout
-            AbsoluteLayout.LayoutBounds="0,0,1,1"
-            AbsoluteLayout.LayoutFlags="All"
-            Padding="20" Spacing="15">
-            <Label FontSize="16" Text="Proveedor"/>
-        <Entry
-            Keyboard="Text"
-            Placeholder="Ingrese Un Proveedor"
-            Text="{Binding Name, Mode=TwoWay}"
-            AutomationId="EntryProvider"/>
-        <Button
-            BackgroundColor="Green"
-            Clicked="Button_Clicked_1"
-            CornerRadius="10"
-            Text="Enviar Datos"
-            TextColor="White"
-            AutomationId="ButtonSendData"/>
-    </VerticalStackLayout>
+        <ScrollView AbsoluteLayout.LayoutBounds="0,0,1,1"
+                    AbsoluteLayout.LayoutFlags="All">
+            <VerticalStackLayout Padding="20" Spacing="15">
+                <Label FontSize="16" Text="Proveedor"/>
+                <Entry Keyboard="Text" Placeholder="Ingrese Un Proveedor" Text="{Binding Name, Mode=TwoWay}" AutomationId="EntryProvider"/>
+                <Button BackgroundColor="Green"
+                        Clicked="Button_Clicked_1"
+                        CornerRadius="10"
+                        Text="Guardar Proveedor"
+                        TextColor="White"
+                        AutomationId="ButtonSendData"/>
+
+
+                <Label FontSize="16" Text="Lista de Proveedores" Margin="0,20,0,0"/>
+
+                <CollectionView ItemsSource="{Binding ProviderList}">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                            <VerticalStackLayout>
+                                <!--<Label Text="{Binding Number,StringFormat='Compartimiento {0:N0}'}" FontSize="16" Grid.Row="1" Grid.Column="3" HorizontalOptions="Center" Margin="0,20,0,5"/>-->
+                                <Frame Padding="0">
+                                    <Grid ColumnDefinitions="20,*,10" RowDefinitions="10,*,10">
+                                        <Label Text="{Binding Name}" Grid.Row="1" Grid.Column="1"/>
+                                    </Grid>
+                                </Frame>
+                            </VerticalStackLayout>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </VerticalStackLayout>
+        </ScrollView>
         <controls:LoadingView x:Name="LoadingOverlay"
               AbsoluteLayout.LayoutBounds="0,0,1,1"
               AbsoluteLayout.LayoutFlags="All"


### PR DESCRIPTION
## Summary by Sourcery

Implement data loading for provider and compartiment services with pagination, refactor the dispenser popup logic for value and color updates, and correct hover button popup color animations.

New Features:
- Add ProviderApiResponse and ProviderResponse models to represent provider API data.
- Implement GetProvidersAsync in ProviderService to fetch and bind the providers list on initialization.

Bug Fixes:
- Populate ProviderList and CompartimentList at service initialization to prevent empty lists in views.
- Fix HoverButtonPopup color animation to capture and restore the original background color instead of using a static default.

Enhancements:
- Invoke GetCompartimentAsync in CompartimentService startup and include PageNumber and PageSize parameters for paginated API requests.
- Refactor AddDispenser popup to consolidate accumulated value and color update logic into reusable methods.