### PR TITLE
add loading in CourtPostView

### DIFF
--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
@@ -152,7 +152,15 @@ public partial class CourtPostView : ContentPage
 
             var selectedId = vm.SelectedEds.IdEds;
 
-            await vm.SendCourtDataAsync();
+            try
+            {
+                LoadingOverlay.ShowLoading();
+                await vm.SendCourtDataAsync();
+            }
+            finally
+            {
+                LoadingOverlay.HideLoading();
+            }
 
             if (vm.LastSendWasSuccessful)
             {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Show a loading overlay before calling SendCourtDataAsync and hide it in a finally block after the call completes