### PR TITLE
Dilan translation main changes

### DIFF
--- a/APP.Eds/APP.Eds/MauiProgram.cs
+++ b/APP.Eds/APP.Eds/MauiProgram.cs
@@ -1,5 +1,8 @@
 ﻿using CommunityToolkit.Maui;
 using Microsoft.Extensions.Logging;
+using APP.Eds.Services.Translations;
+using APP.Eds.Services.Config;
+using APP.Eds.Ports;
 
 namespace APP.Eds
 {
@@ -12,15 +15,30 @@ namespace APP.Eds
             .UseMauiApp<App>()
             .UseMauiCommunityToolkit();
             builder.UseMauiApp<App>().ConfigureFonts(fonts =>
-
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
-            }).UseMauiCommunityToolkit();
+            });
+
+            builder.Services.AddSingleton<ITranslationsService, TranslationsService>();
+
 #if DEBUG
             builder.Logging.AddDebug();
 #endif
-            return builder.Build();
+            var app = builder.Build();
+
+            // Cargar traducciones al inicio
+            Task.Run(async () =>
+            {
+                var translationService = app.Services.GetService<ITranslationsService>();
+                if (translationService != null)
+                {
+                    var translations = await translationService.GetTranslationsByLanguageAsync("es"); // Asumiendo español como idioma predeterminado
+                    GlobalTranslations.SetTranslations(translations);
+                }
+            }).Wait(); // Esperar a que las traducciones se carguen antes de continuar
+
+            return app;
         }
     }
 }

--- a/APP.Eds/APP.Eds/Services/Navigation/MainService.cs
+++ b/APP.Eds/APP.Eds/Services/Navigation/MainService.cs
@@ -25,20 +25,54 @@ using APP.Eds.UsesCases.TypeOfCollection;
 using APP.Eds.Views.Popups;
 using CommunityToolkit.Maui.Views;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Windows.Input;
+using APP.Eds.Services.Config;
+using APP.Eds.Services.Translations;
 
 namespace APP.Eds.Services.Navigation
 {
-    public class MainService : BindableObject
+    public class MainService : BindableObject, INotifyPropertyChanged
     {
-        public ObservableCollection<CategoryModel> Categories { get; set; }
+        public new event PropertyChangedEventHandler? PropertyChanged;
+
+        public TranslationsService _translations = TranslationsService.GetTranslationServiceInstance();
+        private ObservableCollection<CategoryModel> _categories;
+        public ObservableCollection<CategoryModel> Categories
+        {
+            get => _categories;
+            set
+            {
+                _categories = value;
+                OnPropertyChanged(nameof(Categories));
+            }
+        }
         public bool IsIslander => Preferences.Get("userRole", "") == "User";
 
+        //Translations
+        private String _management;
+        public String Management
+        {
+            get => _management;
+            set
+            {
+                _management = value;
+                OnPropertyChanged(nameof(Management));
+            }
+        }
+        private string _logOutText;
+        public string LogOutText
+        {
+            get => _logOutText;
+            set
+            {
+                _logOutText = value;
+                OnPropertyChanged(nameof(LogOutText));
+            }
+        }
         public ICommand NavigateToCourtCommand { get; }
         public MainService()
         {
-           var userRole = Preferences.Get("userRole", "");
-
             NavigateToCourtCommand = new Command(async () =>
             {
                 if (Application.Current?.MainPage is NavigationPage navPage)
@@ -47,14 +81,20 @@ namespace APP.Eds.Services.Navigation
                 }
             });
 
+            Categories = new ObservableCollection<CategoryModel>();
+        }
+        public async Task InitializeAsync() {
             
+            await LoadTranslationsAsync();
+
+            var userRole = Preferences.Get("userRole", "");
 
             if (userRole == "Admin")
             {
 
                 Categories = new ObservableCollection<CategoryModel>
-            {
-                new("Administración", new List<MenuItemModel>
+                {
+                new(Management, new List<MenuItemModel>
                 {
                     new("Corte", typeof(CourtPostView)),
                     new("Negocio", typeof(BusinessPostView)),
@@ -94,16 +134,23 @@ namespace APP.Eds.Services.Navigation
                  new("Inventario",
                 [
                     new("Inventario", typeof(InventoryPostView)),
-                 
+
                 ]),
-            };
+                };
             }
             else
             {
                 Categories = new ObservableCollection<CategoryModel>();
             }
         }
-
+        public async Task LoadTranslationsAsync()
+        {
+            var result = await _translations.GetTranslationsByLanguageAsync("es-CO");
+            GlobalTranslations.SetTranslations(result ?? []);
+            Management = GlobalTranslations.Get("Management");
+            LogOutText = GlobalTranslations.Get("Logout");
+            //Todas las demas variables de traducción que necesites
+        }
         public class CategoryModel
         {
             public string Title { get; set; }
@@ -149,6 +196,11 @@ namespace APP.Eds.Services.Navigation
                 });
 
             }
+        }
+
+        protected void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/APP.Eds/APP.Eds/Services/Navigation/MainService.cs
+++ b/APP.Eds/APP.Eds/Services/Navigation/MainService.cs
@@ -71,6 +71,305 @@ namespace APP.Eds.Services.Navigation
             }
         }
         public ICommand NavigateToCourtCommand { get; }
+
+        // Nuevas variables de traducción
+        private string _courtText;
+        public string CourtText
+        {
+            get => _courtText;
+            set
+            {
+                _courtText = value;
+                OnPropertyChanged(nameof(CourtText));
+            }
+        }
+
+        private string _businessText;
+        public string BusinessText
+        {
+            get => _businessText;
+            set
+            {
+                _businessText = value;
+                OnPropertyChanged(nameof(BusinessText));
+            }
+        }
+
+        private string _providerText;
+        public string ProviderText
+        {
+            get => _providerText;
+            set
+            {
+                _providerText = value;
+                OnPropertyChanged(nameof(ProviderText));
+            }
+        }
+
+        private string _tanksAndCompartmentsText;
+        public string TanksAndCompartmentsText
+        {
+            get => _tanksAndCompartmentsText;
+            set
+            {
+                _tanksAndCompartmentsText = value;
+                OnPropertyChanged(nameof(TanksAndCompartmentsText));
+            }
+        }
+
+        private string _capacityText;
+        public string CapacityText
+        {
+            get => _capacityText;
+            set
+            {
+                _capacityText = value;
+                OnPropertyChanged(nameof(CapacityText));
+            }
+        }
+
+        private string _compartmentText;
+        public string CompartmentText
+        {
+            get => _compartmentText;
+            set
+            {
+                _compartmentText = value;
+                OnPropertyChanged(nameof(CompartmentText));
+            }
+        }
+
+        private string _compartmentCapacityText;
+        public string CompartmentCapacityText
+        {
+            get => _compartmentCapacityText;
+            set
+            {
+                _compartmentCapacityText = value;
+                OnPropertyChanged(nameof(CompartmentCapacityText));
+            }
+        }
+
+        private string _edsTankText;
+        public string EdsTankText
+        {
+            get => _edsTankText;
+            set
+            {
+                _edsTankText = value;
+                OnPropertyChanged(nameof(EdsTankText));
+            }
+        }
+
+        private string _tankText;
+        public string TankText
+        {
+            get => _tankText;
+            set
+            {
+                _tankText = value;
+                OnPropertyChanged(nameof(TankText));
+            }
+        }
+
+        private string _productCompartmentText;
+        public string ProductCompartmentText
+        {
+            get => _productCompartmentText;
+            set
+            {
+                _productCompartmentText = value;
+                OnPropertyChanged(nameof(ProductCompartmentText));
+            }
+        }
+
+        private string _dispensersAndHosesText;
+        public string DispensersAndHosesText
+        {
+            get => _dispensersAndHosesText;
+            set
+            {
+                _dispensersAndHosesText = value;
+                OnPropertyChanged(nameof(DispensersAndHosesText));
+            }
+        }
+
+        private string _dispensersText;
+        public string DispensersText
+        {
+            get => _dispensersText;
+            set
+            {
+                _dispensersText = value;
+                OnPropertyChanged(nameof(DispensersText));
+            }
+        }
+
+        private string _dispenserTypeText;
+        public string DispenserTypeText
+        {
+            get => _dispenserTypeText;
+            set
+            {
+                _dispenserTypeText = value;
+                OnPropertyChanged(nameof(DispenserTypeText));
+            }
+        }
+
+        private string _hoseText;
+        public string HoseText
+        {
+            get => _hoseText;
+            set
+            {
+                _hoseText = value;
+                OnPropertyChanged(nameof(HoseText));
+            }
+        }
+
+        private string _hoseHistoryText;
+        public string HoseHistoryText
+        {
+            get => _hoseHistoryText;
+            set
+            {
+                _hoseHistoryText = value;
+                OnPropertyChanged(nameof(HoseHistoryText));
+            }
+        }
+
+        private string _productsAndPurchasesText;
+        public string ProductsAndPurchasesText
+        {
+            get => _productsAndPurchasesText;
+            set
+            {
+                _productsAndPurchasesText = value;
+                OnPropertyChanged(nameof(ProductsAndPurchasesText));
+            }
+        }
+
+        private string _productText;
+        public string ProductText
+        {
+            get => _productText;
+            set
+            {
+                _productText = value;
+                OnPropertyChanged(nameof(ProductText));
+            }
+        }
+
+        private string _productTypeText;
+        public string ProductTypeText
+        {
+            get => _productTypeText;
+            set
+            {
+                _productTypeText = value;
+                OnPropertyChanged(nameof(ProductTypeText));
+            }
+        }
+
+        private string _purchasesText;
+        public string PurchasesText
+        {
+            get => _purchasesText;
+            set
+            {
+                _purchasesText = value;
+                OnPropertyChanged(nameof(PurchasesText));
+            }
+        }
+
+        private string _edsAndOthersText;
+        public string EdsAndOthersText
+        {
+            get => _edsAndOthersText;
+            set
+            {
+                _edsAndOthersText = value;
+                OnPropertyChanged(nameof(EdsAndOthersText));
+            }
+        }
+
+        private string _registerEdsText;
+        public string RegisterEdsText
+        {
+            get => _registerEdsText;
+            set
+            {
+                _registerEdsText = value;
+                OnPropertyChanged(nameof(RegisterEdsText));
+            }
+        }
+
+        private string _expenseTypeText;
+        public string ExpenseTypeText
+        {
+            get => _expenseTypeText;
+            set
+            {
+                _expenseTypeText = value;
+                OnPropertyChanged(nameof(ExpenseTypeText));
+            }
+        }
+
+        private string _registerIslanderText;
+        public string RegisterIslanderText
+        {
+            get => _registerIslanderText;
+            set
+            {
+                _registerIslanderText = value;
+                OnPropertyChanged(nameof(RegisterIslanderText));
+            }
+        }
+
+        private string _islandText;
+        public string IslandText
+        {
+            get => _islandText;
+            set
+            {
+                _islandText = value;
+                OnPropertyChanged(nameof(IslandText));
+            }
+        }
+
+        private string _categoryText;
+        public string CategoryText
+        {
+            get => _categoryText;
+            set
+            {
+                _categoryText = value;
+                OnPropertyChanged(nameof(CategoryText));
+            }
+        }
+
+        private string _collectionTypeText;
+        public string CollectionTypeText
+        {
+            get => _collectionTypeText;
+            set
+            {
+                _collectionTypeText = value;
+                OnPropertyChanged(nameof(CollectionTypeText));
+            }
+        }
+
+        private string _inventoryText;
+        public string InventoryText
+        {
+            get => _inventoryText;
+            set
+            {
+                _inventoryText = value;
+                OnPropertyChanged(nameof(InventoryText));
+            }
+        }
+
         public MainService()
         {
             NavigateToCourtCommand = new Command(async () =>
@@ -82,6 +381,7 @@ namespace APP.Eds.Services.Navigation
             });
 
             Categories = new ObservableCollection<CategoryModel>();
+            LoadTranslationsAsync();
         }
         public async Task InitializeAsync() {
             
@@ -96,44 +396,44 @@ namespace APP.Eds.Services.Navigation
                 {
                 new(Management, new List<MenuItemModel>
                 {
-                    new("Corte", typeof(CourtPostView)),
-                    new("Negocio", typeof(BusinessPostView)),
-                    new("Proveedor", typeof(ProviderPostView))
+                    new(CourtText, typeof(CourtPostView)),
+                    new(BusinessText, typeof(BusinessPostView)),
+                    new(ProviderText, typeof(ProviderPostView))
                 }),
-                new("Tanques y Compartimentos", new List<MenuItemModel>
+                new(TanksAndCompartmentsText, new List<MenuItemModel>
                 {
-                    new("Capacidad", typeof(CapacityPostView)),
-                    new("Compartimento", typeof(CompartimentPostView)),
-                    new("Capacidad Del Compartimento", typeof(CompartimentCapacityPostView)),
-                    new("Tanque EDS", typeof(EdsTankPostView)),
-                    new("Tanque", typeof(TankPostView)),
-                    new("Compartimento Del Producto", typeof(ProductCompartimentPostView))
+                    new(CapacityText, typeof(CapacityPostView)),
+                    new(CompartmentText, typeof(CompartimentPostView)),
+                    new(CompartmentCapacityText, typeof(CompartimentCapacityPostView)),
+                    new(EdsTankText, typeof(EdsTankPostView)),
+                    new(TankText, typeof(TankPostView)),
+                    new(ProductCompartmentText, typeof(ProductCompartimentPostView))
                 }),
-                new("Dispensadores y Mangueras", new List<MenuItemModel>
+                new(DispensersAndHosesText, new List<MenuItemModel>
                 {
-                    new("Dispensadores", typeof(DispensersPostView)),
-                    new("Tipo De Dispensador", typeof(DispenserTypePostView)),
-                    new("Manguera", typeof(HosePostView)),
-                    new("Historial De La Manguera", typeof(HoseHistoryPostView))
+                    new(DispensersText, typeof(DispensersPostView)),
+                    new(DispenserTypeText, typeof(DispenserTypePostView)),
+                    new(HoseText, typeof(HosePostView)),
+                    new(HoseHistoryText, typeof(HoseHistoryPostView))
                 }),
-                new("Productos y Compras", new List<MenuItemModel>
+                new(ProductsAndPurchasesText, new List<MenuItemModel>
                 {
-                    new("Producto", typeof(ProductPostView)),
-                    new("Tipo De P1roducto", typeof(ProductTypePostView)),
-                    new("Compras", typeof(ShoppingPostView)),
+                    new(ProductText, typeof(ProductPostView)),
+                    new(ProductTypeText, typeof(ProductTypePostView)),
+                    new(PurchasesText, typeof(ShoppingPostView)),
                 }),
-                new("EDS y Otros", new List<MenuItemModel>
+                new(EdsAndOthersText, new List<MenuItemModel>
                 {
-                    new("Registre Una EDS", typeof(EdsPostView)),
-                    new("Tipo De Gastos", typeof(ExpendituresPostView)),
-                    new("Registre Un Islero", typeof(IslanderPostView)),
-                     new("Isla", typeof(IslandPostView)),
-                    new("Categoría", typeof(CategoryPostView)),
-                    new("Tipo De Colección", typeof(TypeOfCollectionPostView))
+                    new(RegisterEdsText, typeof(EdsPostView)),
+                    new(ExpenseTypeText, typeof(ExpendituresPostView)),
+                    new(RegisterIslanderText, typeof(IslanderPostView)),
+                     new(IslandText, typeof(IslandPostView)),
+                    new(CategoryText, typeof(CategoryPostView)),
+                    new(CollectionTypeText, typeof(TypeOfCollectionPostView))
                 }),
-                 new("Inventario",
+                 new(InventoryText,
                 [
-                    new("Inventario", typeof(InventoryPostView)),
+                    new(InventoryText, typeof(InventoryPostView)),
 
                 ]),
                 };
@@ -149,6 +449,33 @@ namespace APP.Eds.Services.Navigation
             GlobalTranslations.SetTranslations(result ?? []);
             Management = GlobalTranslations.Get("Management");
             LogOutText = GlobalTranslations.Get("Logout");
+            CourtText = GlobalTranslations.Get("Court");
+            BusinessText = GlobalTranslations.Get("Business");
+            ProviderText = GlobalTranslations.Get("Provider");
+            TanksAndCompartmentsText = "Tanques y Compartimentos";
+            CapacityText = GlobalTranslations.Get("Capacity");
+            CompartmentText = GlobalTranslations.Get("Compartment");
+            CompartmentCapacityText = GlobalTranslations.Get("CompartmentCapacity");
+            EdsTankText = GlobalTranslations.Get("EdsTank");
+            TankText = GlobalTranslations.Get("Tank");
+            ProductCompartmentText = GlobalTranslations.Get("ProductCompartment");
+            DispensersAndHosesText = "Dispensadores y Mangueras";
+            DispensersText = GlobalTranslations.Get("Dispensers");
+            DispenserTypeText = GlobalTranslations.Get("DispenserType");
+            HoseText = GlobalTranslations.Get("Hose");
+            HoseHistoryText = GlobalTranslations.Get("HoseHistory");
+            ProductsAndPurchasesText = "Productos y Compras";
+            ProductText = GlobalTranslations.Get("Product");
+            ProductTypeText = GlobalTranslations.Get("ProductType");
+            PurchasesText = GlobalTranslations.Get("Purchases");
+            EdsAndOthersText = "EDS y Otros";
+            RegisterEdsText = GlobalTranslations.Get("RegisterEds");
+            ExpenseTypeText = GlobalTranslations.Get("ExpenseType");
+            RegisterIslanderText = GlobalTranslations.Get("RegisterIslander");
+            IslandText = GlobalTranslations.Get("Island");
+            CategoryText = GlobalTranslations.Get("Category");
+            CollectionTypeText = GlobalTranslations.Get("CollectionType");
+            InventoryText = "Inventario";
             //Todas las demas variables de traducción que necesites
         }
         public class CategoryModel

--- a/APP.Eds/APP.Eds/Services/Translations/TranslationService.cs
+++ b/APP.Eds/APP.Eds/Services/Translations/TranslationService.cs
@@ -9,6 +9,7 @@ namespace APP.Eds.Services.Translations;
 
 public class TranslationsService : ITranslationsService
 {
+    private static TranslationsService? translationsService;
     private string? _authToken;
 
 
@@ -31,6 +32,14 @@ public class TranslationsService : ITranslationsService
         return data.Translations.TryGetValue(languageTag, out var translations)
             ? translations
             : new Dictionary<string, string>();
+    }
+
+    public static TranslationsService GetTranslationServiceInstance(){
+        if (translationsService == null)
+        {
+            translationsService = new TranslationsService();
+        }
+        return translationsService;
     }
 
 }

--- a/APP.Eds/APP.Eds/UsesCases/Navigation/Main.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Navigation/Main.xaml
@@ -34,7 +34,7 @@
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
                 </CollectionView>
-                <Button Text="Cerrar Sesión"
+                <Button Text="{Binding LogOutText}"
                         Clicked="OnLogoutClicked"
                         BackgroundColor="Red"
                         TextColor="White"

--- a/APP.Eds/APP.Eds/UsesCases/Navigation/Main.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Navigation/Main.xaml.cs
@@ -6,11 +6,17 @@ namespace APP.Eds.UsesCases.Navigation;
 public partial class Main : ContentPage
 {
     private KeycloakSessionManager _sessionManager;
+    private readonly MainService _service = new MainService();
     public Main()
 	{
         InitializeComponent();
-        BindingContext = new MainService();
+        BindingContext = _service;
+        InitAsync();
         _sessionManager = new KeycloakSessionManager();
+    }
+    private async void InitAsync()
+    {
+        await _service.InitializeAsync();
     }
     private async void OnLogoutClicked(object sender, EventArgs e)
     {


### PR DESCRIPTION
## Summary by Sourcery

Integrate language translations into the main navigation by loading localized strings at startup and binding all menu item labels to translation properties via INotifyPropertyChanged.

New Features:
- Add TranslationsService integration to fetch and apply translations for the main navigation UI.
- Introduce translation properties in MainService for each menu section and item and update labels dynamically.
- Register ITranslationsService in the DI container and load default language translations on app startup.
- Expose an async InitializeAsync in MainService to build the navigation menu using translated strings.
- Update Main.xaml.cs to use a single MainService instance and wait for translation initialization.

Enhancements:
- Refactor MainService to implement INotifyPropertyChanged and use observable properties for menu categories and labels.
- Refactor MauiProgram to synchronously wait for initial translations load before running the app.

Build:
- Add ITranslationsService singleton registration in MauiProgram.
- Perform initial translation load in MauiProgram before returning the built app.