### PR TITLE
DataValidation

### DIFF
--- a/APP.Eds/APP.Eds/APP.Eds.csproj
+++ b/APP.Eds/APP.Eds/APP.Eds.csproj
@@ -79,27 +79,21 @@
 	  <AndroidResource Remove="NewFolder\**" />
 	  <AndroidResource Remove="Services\ClearFields\**" />
 	  <AndroidResource Remove="TestAutomation\**" />
-	  <AndroidResource Remove="UsesCases\Behaviors\**" />
 	  <Compile Remove="NewFolder\**" />
 	  <Compile Remove="Services\ClearFields\**" />
 	  <Compile Remove="TestAutomation\**" />
-	  <Compile Remove="UsesCases\Behaviors\**" />
 	  <EmbeddedResource Remove="NewFolder\**" />
 	  <EmbeddedResource Remove="Services\ClearFields\**" />
 	  <EmbeddedResource Remove="TestAutomation\**" />
-	  <EmbeddedResource Remove="UsesCases\Behaviors\**" />
 	  <MauiCss Remove="NewFolder\**" />
 	  <MauiCss Remove="Services\ClearFields\**" />
 	  <MauiCss Remove="TestAutomation\**" />
-	  <MauiCss Remove="UsesCases\Behaviors\**" />
 	  <MauiXaml Remove="NewFolder\**" />
 	  <MauiXaml Remove="Services\ClearFields\**" />
 	  <MauiXaml Remove="TestAutomation\**" />
-	  <MauiXaml Remove="UsesCases\Behaviors\**" />
 	  <None Remove="NewFolder\**" />
 	  <None Remove="Services\ClearFields\**" />
 	  <None Remove="TestAutomation\**" />
-	  <None Remove="UsesCases\Behaviors\**" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/APP.Eds/APP.Eds/Services/Business/BusinessService.cs
+++ b/APP.Eds/APP.Eds/Services/Business/BusinessService.cs
@@ -37,7 +37,22 @@ public class BusinessService : INotifyPropertyChanged
         set
         {
             _name = value;
+            ValidateName();
             OnPropertyChanged(nameof(Name));
+        }
+    }
+
+    private bool _showNameError;
+    public bool ShowNameError
+    {
+        get => _showNameError;
+        set
+        {
+            if (_showNameError != value)
+            {
+                _showNameError = value;
+                OnPropertyChanged(nameof(ShowNameError));
+            }
         }
     }
 
@@ -78,12 +93,10 @@ public class BusinessService : INotifyPropertyChanged
 
     public async Task SaveBusinessDataAsync()
     {
-        
-        if (string.IsNullOrWhiteSpace(Name))
+        ValidateName();
+        if (ShowNameError || string.IsNullOrWhiteSpace(Name))
         {
-
-            await Application.Current.MainPage.DisplayAlert("Error de Validación", "Debe ingresar los datos en el campo de nombre.", "Aceptar");
-            return; 
+            return;
         }
 
         if (string.IsNullOrEmpty(_authToken))
@@ -123,6 +136,11 @@ public class BusinessService : INotifyPropertyChanged
         {
             await Application.Current.MainPage.DisplayAlert("Error", $"Error al enviar los datos: {ex.Message}", "OK");
         }
+    }
+
+    private void ValidateName()
+    {
+        ShowNameError = string.IsNullOrWhiteSpace(Name) || !System.Text.RegularExpressions.Regex.IsMatch(Name, @"^[a-zA-Z\s]*$");
     }
 
     protected void OnPropertyChanged(string propertyName)

--- a/APP.Eds/APP.Eds/UsesCases/Behaviors/LettersOnlyBehavior.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Behaviors/LettersOnlyBehavior.cs
@@ -1,0 +1,41 @@
+using Microsoft.Maui.Controls;
+
+namespace APP.Eds.UsesCases.Behaviors
+{
+    public class LettersOnlyBehavior : Behavior<Entry>
+    {
+        protected override void OnAttachedTo(Entry entry)
+        {
+            entry.TextChanged += OnEntryTextChanged;
+            base.OnAttachedTo(entry);
+        }
+
+        protected override void OnDetachingFrom(Entry entry)
+        {
+            entry.TextChanged -= OnEntryTextChanged;
+            base.OnDetachingFrom(entry);
+        }
+
+        private void OnEntryTextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (sender is Entry entry)
+            {
+                string newText = e.NewTextValue;
+                string oldText = e.OldTextValue;
+
+                if (string.IsNullOrEmpty(newText))
+                {
+                    return;
+                }
+
+                // Permitir solo letras y espacios
+                bool isValid = System.Text.RegularExpressions.Regex.IsMatch(newText, @"^[a-zA-Z\s]*$");
+
+                if (!isValid)
+                {
+                    entry.Text = oldText;
+                }
+            }
+        }
+    }
+}

--- a/APP.Eds/APP.Eds/UsesCases/Bussines/BusinessPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Bussines/BusinessPostView.xaml
@@ -3,26 +3,36 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="APP.Eds.UsesCases.Business.BusinessPostView"
              xmlns:controls="clr-namespace:APP.Eds.UsesCases.LoadingView"
+             xmlns:behaviors="clr-namespace:APP.Eds.UsesCases.Behaviors"
              Title="Gestion De Negocios">
-    <AbsoluteLayout>
-        <VerticalStackLayout
-            AbsoluteLayout.LayoutBounds="0,0,1,1"
-            AbsoluteLayout.LayoutFlags="All"
-            Padding="20" Spacing="15">
-        <Label FontSize="16" Text="Negocio"/>
-        <Entry
-            Keyboard="Text"
-            Placeholder="Ingrese Un Negocio"
-            Text="{Binding Name, Mode=TwoWay}"
-            AutomationId="EntryBusinessName"/>
-            <Button
-            BackgroundColor="Green"
-            Clicked="Button_Clicked_1"
-            CornerRadius="10"
-            Text="Enviar Datos"
-            TextColor="White"
-            AutomationId="ButtonSendBusinessData"/>
-        </VerticalStackLayout>
+     <AbsoluteLayout>
+         <VerticalStackLayout
+             AbsoluteLayout.LayoutBounds="0,0,1,1"
+             AbsoluteLayout.LayoutFlags="All"
+             Padding="20" Spacing="15">
+         <Label FontSize="16" Text="Negocio"/>
+         <Entry
+             Keyboard="Text"
+             Placeholder="Ingrese Un Negocio"
+             Text="{Binding Name, Mode=TwoWay}"
+             AutomationId="EntryBusinessName">
+             <Entry.Behaviors>
+                 <behaviors:LettersOnlyBehavior />
+             </Entry.Behaviors>
+         </Entry>
+         <Label x:Name="NameErrorLabel"
+                Text="Por favor, ingrese un nombre válido. Solo se permiten letras."
+                TextColor="Red"
+                IsVisible="{Binding ShowNameError}"
+                FontSize="12"/>
+             <Button
+             BackgroundColor="Green"
+             Clicked="Button_Clicked_1"
+             CornerRadius="10"
+             Text="Enviar Datos"
+             TextColor="White"
+             AutomationId="ButtonSendBusinessData"/>
+         </VerticalStackLayout>
 
         <controls:LoadingView x:Name="LoadingOverlay"
                       AbsoluteLayout.LayoutBounds="0,0,1,1"


### PR DESCRIPTION
## Summary by Sourcery

Add regex-based validation for business name input with an error flag and restrict UI entry to letters only

New Features:
- Expose ShowNameError and ValidateName in BusinessService to flag invalid name input
- Invoke ValidateName in Name setter and SaveBusinessDataAsync to prevent saving when the name is invalid
- Introduce LettersOnlyBehavior to MAUI Entry controls to allow only letters and spaces