### PR TITLE
fix(APK in S3): Enhance name of APK files uploaded

### DIFF
--- a/.github/workflows/CI build.yml
+++ b/.github/workflows/CI build.yml
@@ -152,7 +152,15 @@ jobs:
 
       - name: Upload APK to S3
         run: |
-          aws s3 cp ./downloaded-artifacts/*Signed.apk s3://${{ secrets.S3_BUCKET_NAME }}/android/${{ github.sha }}-app.apk --acl private
+          TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+          APK_FILE=$(find ./downloaded-artifacts -name "*Signed.apk" -print -quit)
+          if [ -z "$APK_FILE" ]; then
+            echo "Error: No se encontró ningún archivo APK firmado en ./downloaded-artifacts"
+            exit 1
+          fi
+          NEW_APK_NAME="App-Eds-${TIMESTAMP}.apk"
+          mv "$APK_FILE" "./downloaded-artifacts/$NEW_APK_NAME"
+          aws s3 cp "./downloaded-artifacts/$NEW_APK_NAME" s3://${{ secrets.S3_BUCKET_NAME }}/android/${NEW_APK_NAME} --acl private
         
 # MAUI Windows Build
   build-windows:


### PR DESCRIPTION
## Summary by Sourcery

Improve APK upload in CI by adding timestamped, prefixed filenames and validating the presence of the signed APK before uploading

CI:
- Rename uploaded APK to include “App-Eds-<TIMESTAMP>.apk” instead of using the Git SHA
- Check for a signed APK in downloaded-artifacts and fail the workflow if none is found