### PR TITLE
acceptletter

### DIFF
--- a/APP.Eds/APP.Eds/Services/Expenditures/ExpendituresService.cs
+++ b/APP.Eds/APP.Eds/Services/Expenditures/ExpendituresService.cs
@@ -79,6 +79,13 @@ namespace APP.Eds.Services.Expenditures
                 return;
             }
 
+            // Validar que la descripción sea un número
+            if (!decimal.TryParse(Description, out _))
+            {
+                await Application.Current.MainPage.DisplayAlert("Error de Validación", "El campo 'Monto' solo acepta valores numéricos.", "OK");
+                return; // Detener la operación si la validación falla
+            }
+
             try
             {
                 Expenditures = new ExpendituresModel

--- a/APP.Eds/APP.Eds/UsesCases/Expenditures/ExpendituresPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Expenditures/ExpendituresPostView.xaml
@@ -11,7 +11,7 @@
             Padding="20" Spacing="15">
             <Label FontSize="16" Text="Gastos"/>
             <Entry
-            Keyboard="Text"
+            Keyboard="Numeric"
             Placeholder="Ingrese Un Gasto"
             Text="{Binding Description, Mode=TwoWay}"
             AutomationId="EntryExpenditures"/>


### PR DESCRIPTION
## Summary by Sourcery

Add numeric validation for the 'Monto' field when saving expenditures to prevent non-numeric input and display an error alert

Enhancements:
- Validate that the Description input is a decimal number before saving expenditures
- Show a validation alert and halt the save operation if the amount field contains non-numeric characters