### PR TITLE
Hu 008 bug error additional information

### DIFF
--- a/APP.Eds/APP.Eds/Components/PopUp/AddInfo.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddInfo.xaml
@@ -44,6 +44,12 @@
                         AutomationId="EditorDescription"/>
                 </VerticalStackLayout>
             </Frame>
+            
+            <!-- Botones de Acción -->
+            <Grid Grid.Row="1" ColumnDefinitions="*,*" ColumnSpacing="10" Margin="0,10,0,0">
+                <Button Grid.Column="0" Text="Cancelar" Clicked="OnCloseTapped" BackgroundColor="#E0E0E0" TextColor="#6200E8" CornerRadius="10" AutomationId="ButtonCancelAddInfo"/>
+                <Button Grid.Column="1" Text="Guardar" Clicked="OnSaveTapped" BackgroundColor="#6200E8" TextColor="White" CornerRadius="10" AutomationId="ButtonSaveAddInfo"/>
+            </Grid>
         </Grid>
     </Frame>
 </mct:Popup>

--- a/APP.Eds/APP.Eds/Components/PopUp/AddInfo.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddInfo.xaml.cs
@@ -17,5 +17,26 @@ public partial class AddInfo : Popup
     {
         Close();
     }
-}   
+
+    private async void OnSaveTapped(object sender, EventArgs e)
+    {
+        // Access the Editor by its AutomationId to get the entered text.
+        var editor = this.FindByName<Editor>("EditorDescription");
+
+        if (editor != null && !string.IsNullOrWhiteSpace(editor.Text))
+        {
+            // Assuming CourtService has a method to save additional info.
+            // The exact method name and parameters are unknown.
+            // I'll use a placeholder method `SaveAdditionalInfoAsync` for now.
+            // The user might need to provide the correct method name or signature.
+            await courtService.SaveAdditionalInfoAsync(editor.Text);
+            Close(); // Close the popup after saving.
+        }
+        else
+        {
+            // If the editor is empty or not found, just close the popup.
+            Close();
+        }
+    }
+
 

--- a/APP.Eds/APP.Eds/Components/PopUp/AddInfo.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddInfo.xaml.cs
@@ -20,23 +20,16 @@ public partial class AddInfo : Popup
 
     private async void OnSaveTapped(object sender, EventArgs e)
     {
-        // Access the Editor by its AutomationId to get the entered text.
         var editor = this.FindByName<Editor>("EditorDescription");
 
         if (editor != null && !string.IsNullOrWhiteSpace(editor.Text))
         {
-            // Assuming CourtService has a method to save additional info.
-            // The exact method name and parameters are unknown.
-            // I'll use a placeholder method `SaveAdditionalInfoAsync` for now.
-            // The user might need to provide the correct method name or signature.
             await courtService.SaveAdditionalInfoAsync(editor.Text);
-            Close(); // Close the popup after saving.
+            Close();
         }
         else
         {
-            // If the editor is empty or not found, just close the popup.
             Close();
         }
     }
-
-
+}

--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -2526,6 +2526,12 @@ GetAllEdsData()
             }
         }
 
+        public async Task SaveAdditionalInfoAsync(string description)
+        {
+            AdditionalInfoDescription = description;
+            OnPropertyChanged(nameof(AdditionalInfoDescription));
+        }
+
         private void UpdateDateEndtime()
         {
             if (Endtime < Starttime)

--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -2264,6 +2264,7 @@ namespace APP.Eds.Services.Court
             _authToken = TokenHelper.LoadToken(Configuration.KeycloakCliendId, Configuration.KeycloakRealms);
             
 
+
             HideLists = new Command(() =>
             {
                 VisibleLists = !VisibleLists;


### PR DESCRIPTION
## Summary by Sourcery

Add save functionality for the additional information popup and persist the entered description in the court service.

New Features:
- Introduce OnSaveTapped handler in AddInfo popup to capture user input and invoke the save action before closing the popup.
- Implement SaveAdditionalInfoAsync in CourtService to update the AdditionalInfoDescription property and notify observers.