### PR TITLE
hide menu

### DIFF
--- a/APP.Eds/APP.Eds/Components/PopUp/AddInfo.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddInfo.xaml
@@ -19,7 +19,6 @@
 
             <!--  Encabezado  -->
             <Grid Grid.Row="0" ColumnDefinitions="*, Auto, *" Padding="0,0,0,10">
-                <Label Grid.Column="1" FontAttributes="Bold" FontSize="22" Text="Agregar Informacion Extra" HorizontalTextAlignment="Center" HorizontalOptions="Center" VerticalOptions="Center" AutomationId="LabelAddInfo"/>
                 <Button Grid.Column="2" Margin="10,0,0,0"
                         BackgroundColor="Transparent"
                         Clicked="OnCloseTapped"

--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -673,7 +673,7 @@ namespace APP.Eds.Services.Court
             }
         }
 
-        private bool _visibleDispenser = true;
+        private bool _visibleDispenser = false;
         public bool VisibleDispenser
         {
             get => _visibleDispenser;
@@ -685,7 +685,7 @@ namespace APP.Eds.Services.Court
         }
 
 
-        private bool _visibleDocuments = true;
+        private bool _visibleDocuments = false;
         public bool VisibleDocuments
         {
             get => _visibleDocuments;
@@ -696,7 +696,7 @@ namespace APP.Eds.Services.Court
             }
         }
 
-        private bool _visibleExpenses = true;
+        private bool _visibleExpenses = false;
         public bool VisibleExpenses
         {
             get => _visibleExpenses;
@@ -707,7 +707,7 @@ namespace APP.Eds.Services.Court
             }
         }
 
-        private bool _visibleReceipts = true;
+        private bool _visibleReceipts = false;
         public bool VisibleReceipts
         {
             get => _visibleReceipts;
@@ -2710,6 +2710,7 @@ GetAllEdsData()
 
             CourtDispensers.Add(newDispenser);
             Court.CourtDispensers = CourtDispensers.ToList();
+            VisibleDispenser = true; // Make visible after data is added
 
             AddAmountDifferenceResult(AccumulatedAmount, LastAccumulatedAmount);
             AddGallonsDifferenceResult(AccumulatedGallons, LastAccumulatedGallons);
@@ -2763,6 +2764,7 @@ GetAllEdsData()
 
             CourtExpenditures.Add(newCourtExpenditure);
             Court.CourtExpenditures = CourtExpenditures.ToList();
+            VisibleExpenses = true; // Make visible after data is added
 
             TotalSales = GetTotalSales();
             CourtExpenditureAmount = 0;

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
@@ -310,7 +310,6 @@
 
                 <!-- Informacion Adicional -->
                 <Grid ColumnDefinitions="*, auto" x:Name="AdditionalInformation">
-                    <Label Grid.ColumnSpan="2" VerticalOptions="Center" HorizontalOptions="Center" FontAttributes="Bold" FontSize="18" Text="{Binding AdditionalInformation}" />
                     <Button Grid.Column="1"
                             HorizontalOptions="End"
                             FontSize="Medium"


### PR DESCRIPTION
## Summary by Sourcery

Hide court menu sections by default and reveal them only after corresponding data is added

Enhancements:
- Set default visibility of dispenser, documents, expenses, and receipts sections to false
- Automatically enable dispenser section when a new dispenser is added
- Automatically enable expenses section when a new expenditure is added