### PR TITLE
Fix/new price hose

### DIFF
--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
@@ -17,12 +17,16 @@ public partial class AddDispenser : Popup
         this.courtService = courtService;
         SecondEntry.IsEnabled = isGallonsEditable;
         
-        
+        // Check if the current user is an administrator
         CheckUserRole();
     }
 
     private void CheckUserRole()
     {
+        var userRole = Preferences.Get("userRole", "User");
+        isAdmin = userRole == "Admin";
+        
+        // Update UI visibility after role is determined and UI is loaded
         Dispatcher.Dispatch(() => UpdatePriceEditVisibility());
     }
     private void EditGallonsButton_Clicked(object sender, EventArgs e)
@@ -111,9 +115,13 @@ public partial class AddDispenser : Popup
         {
             if (vm.AccumulatedAmount > vm.LastAccumulatedAmount)
             {
-               
+                // Calculate amount difference directly
                 double amountDifference = vm.AccumulatedAmount - vm.LastAccumulatedAmount;
+                
+                // Use the CURRENT price from SelectedHose (which may have been updated)
                 double currentPrice = vm.SelectedHose.Price;
+                
+                // Calculate gallons using current price
                 vm.AccumulatedGallons = vm.LastAccumulatedGallons + (amountDifference / currentPrice);
             }
             UpdateAccumulatedColors();
@@ -149,7 +157,8 @@ public partial class AddDispenser : Popup
                 double price = vm.SelectedHose.Price;
                 PricePerGallonLabel.Text = $"{price:C3}";
                 
-                if (PriceEditEntry != null)
+                // For admin users, also set the editable price entry
+                if (isAdmin && PriceEditEntry != null)
                 {
                     PriceEditEntry.Text = price.ToString("F2");
                 }
@@ -157,13 +166,13 @@ public partial class AddDispenser : Popup
             else
             {
                 PricePerGallonLabel.Text = "##.###";
-                if (PriceEditEntry != null)
+                if (isAdmin && PriceEditEntry != null)
                 {
                     PriceEditEntry.Text = "";
                 }
             }
             
-           
+            // Update UI visibility based on admin status
             UpdatePriceEditVisibility();
         }
         else
@@ -183,6 +192,8 @@ public partial class AddDispenser : Popup
             PriceEditEntry.IsVisible = isAdmin;
             PriceEditButton.IsVisible = isAdmin;
             
+            // For admin users, show editable controls and hide read-only label
+            // For non-admin users, show read-only label and hide editable controls
             if (PricePerGallonLabel != null)
             {
                 PricePerGallonLabel.IsVisible = !isAdmin;
@@ -197,7 +208,7 @@ public partial class AddDispenser : Popup
 
     private void PriceEditEntry_TextChanged(object sender, TextChangedEventArgs e)
     {
-       
+        // Recalculate in real-time as the user types (optional for better UX)
         if (BindingContext is CourtService vm && vm.SelectedHose is not null && PriceEditEntry != null)
         {
             if (double.TryParse(e.NewTextValue, out double newPrice) && newPrice > 0)
@@ -205,7 +216,7 @@ public partial class AddDispenser : Popup
                 vm.SelectedHose.Price = newPrice;
                 PricePerGallonLabel.Text = $"{newPrice:C2}";
                 
-               
+                // Recalculate gallons with new price if amount is already entered
                 if (vm.AccumulatedAmount > vm.LastAccumulatedAmount)
                 {
                     double amountDifference = vm.AccumulatedAmount - vm.LastAccumulatedAmount;
@@ -233,16 +244,19 @@ public partial class AddDispenser : Popup
                 vm.SelectedHose.Price = newPrice;
                 PricePerGallonLabel.Text = $"{newPrice:C2}";
                 
-               
+                // Recalculate gallons using the NEW price instead of relying on AmountDifferenceResult
                 if (vm.AccumulatedAmount > vm.LastAccumulatedAmount)
                 {
                     double amountDifference = vm.AccumulatedAmount - vm.LastAccumulatedAmount;
                     vm.AccumulatedGallons = vm.LastAccumulatedGallons + (amountDifference / newPrice);
+                    
+                    // Update color indicators after recalculation
                     UpdateAccumulatedColors();
                 }
             }
             else
             {
+                // Reset to original price if invalid input
                 PriceEditEntry.Text = vm.SelectedHose.Price.ToString("F2");
             }
         }

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-using System.Globalization;
-using APP.Eds.Services.Court;
+﻿using APP.Eds.Services.Court;
 using CommunityToolkit.Maui.Views;
 
 namespace APP.Eds.Components.PopUp;
@@ -9,7 +7,7 @@ public partial class AddDispenser : Popup
 {
     private readonly CourtService courtService;
     private bool isGallonsEditable = false;
-    private bool isAdmin = false;
+    private bool canEditPrice = false;
 
     public AddDispenser(CourtService courtService)
     {
@@ -17,16 +15,14 @@ public partial class AddDispenser : Popup
         this.courtService = courtService;
         SecondEntry.IsEnabled = isGallonsEditable;
         
-        // Check if the current user is an administrator
         CheckUserRole();
     }
 
     private void CheckUserRole()
     {
         var userRole = Preferences.Get("userRole", "User");
-        isAdmin = userRole == "Admin";
+        canEditPrice = userRole == "Admin" || userRole == "User";
         
-        // Update UI visibility after role is determined and UI is loaded
         Dispatcher.Dispatch(() => UpdatePriceEditVisibility());
     }
     private void EditGallonsButton_Clicked(object sender, EventArgs e)
@@ -115,13 +111,10 @@ public partial class AddDispenser : Popup
         {
             if (vm.AccumulatedAmount > vm.LastAccumulatedAmount)
             {
-                // Calculate amount difference directly
                 double amountDifference = vm.AccumulatedAmount - vm.LastAccumulatedAmount;
                 
-                // Use the CURRENT price from SelectedHose (which may have been updated)
                 double currentPrice = vm.SelectedHose.Price;
                 
-                // Calculate gallons using current price
                 vm.AccumulatedGallons = vm.LastAccumulatedGallons + (amountDifference / currentPrice);
             }
             UpdateAccumulatedColors();
@@ -157,8 +150,7 @@ public partial class AddDispenser : Popup
                 double price = vm.SelectedHose.Price;
                 PricePerGallonLabel.Text = $"{price:C3}";
                 
-                // For admin users, also set the editable price entry
-                if (isAdmin && PriceEditEntry != null)
+                if (canEditPrice && PriceEditEntry != null)
                 {
                     PriceEditEntry.Text = price.ToString("F2");
                 }
@@ -166,19 +158,18 @@ public partial class AddDispenser : Popup
             else
             {
                 PricePerGallonLabel.Text = "##.###";
-                if (isAdmin && PriceEditEntry != null)
+                if (canEditPrice && PriceEditEntry != null)
                 {
                     PriceEditEntry.Text = "";
                 }
             }
             
-            // Update UI visibility based on admin status
             UpdatePriceEditVisibility();
         }
         else
         {
             PricePerGallonLabel.Text = "##.###";
-            if (isAdmin && PriceEditEntry != null)
+            if (canEditPrice && PriceEditEntry != null)
             {
                 PriceEditEntry.Text = "";
             }
@@ -189,14 +180,12 @@ public partial class AddDispenser : Popup
     {
         if (PriceEditEntry != null && PriceEditButton != null)
         {
-            PriceEditEntry.IsVisible = isAdmin;
-            PriceEditButton.IsVisible = isAdmin;
+            PriceEditEntry.IsVisible = canEditPrice;
+            PriceEditButton.IsVisible = canEditPrice;
             
-            // For admin users, show editable controls and hide read-only label
-            // For non-admin users, show read-only label and hide editable controls
             if (PricePerGallonLabel != null)
             {
-                PricePerGallonLabel.IsVisible = !isAdmin;
+                PricePerGallonLabel.IsVisible = !canEditPrice;
             }
         }
     }
@@ -208,7 +197,6 @@ public partial class AddDispenser : Popup
 
     private void PriceEditEntry_TextChanged(object sender, TextChangedEventArgs e)
     {
-        // Recalculate in real-time as the user types (optional for better UX)
         if (BindingContext is CourtService vm && vm.SelectedHose is not null && PriceEditEntry != null)
         {
             if (double.TryParse(e.NewTextValue, out double newPrice) && newPrice > 0)
@@ -216,7 +204,6 @@ public partial class AddDispenser : Popup
                 vm.SelectedHose.Price = newPrice;
                 PricePerGallonLabel.Text = $"{newPrice:C2}";
                 
-                // Recalculate gallons with new price if amount is already entered
                 if (vm.AccumulatedAmount > vm.LastAccumulatedAmount)
                 {
                     double amountDifference = vm.AccumulatedAmount - vm.LastAccumulatedAmount;
@@ -244,19 +231,16 @@ public partial class AddDispenser : Popup
                 vm.SelectedHose.Price = newPrice;
                 PricePerGallonLabel.Text = $"{newPrice:C2}";
                 
-                // Recalculate gallons using the NEW price instead of relying on AmountDifferenceResult
                 if (vm.AccumulatedAmount > vm.LastAccumulatedAmount)
                 {
                     double amountDifference = vm.AccumulatedAmount - vm.LastAccumulatedAmount;
                     vm.AccumulatedGallons = vm.LastAccumulatedGallons + (amountDifference / newPrice);
                     
-                    // Update color indicators after recalculation
                     UpdateAccumulatedColors();
                 }
             }
             else
             {
-                // Reset to original price if invalid input
                 PriceEditEntry.Text = vm.SelectedHose.Price.ToString("F2");
             }
         }


### PR DESCRIPTION
## Summary by Sourcery

Refactor price editing logic by replacing the isAdmin check with a canEditPrice flag derived from userRole preference, and clean up related UI visibility and redundant usings.

Enhancements:
- Replace isAdmin flag with canEditPrice based on stored userRole preference to control price editing permissions
- Allow both Admin and User roles to edit hose price and update price entry and visibility logic accordingly