### PR TITLE
feat(Island) re desing add Island

### DIFF
--- a/APP.Eds/APP.Eds/Services/Island/IslandService.cs
+++ b/APP.Eds/APP.Eds/Services/Island/IslandService.cs
@@ -10,13 +10,93 @@ using System.Windows.Input;
 
 namespace APP.Eds.Services.Island;
 
+// Model class for editable pending islands
+public class EditablePendingIsland : INotifyPropertyChanged
+{
+    private string _name;
+    private int _number;
+
+    public string Name 
+    { 
+        get => _name; 
+        set 
+        { 
+            _name = value; 
+            OnPropertyChanged(nameof(Name)); 
+        } 
+    }
+
+    public int Number
+    {
+        get => _number;
+        set
+        {
+            _number = value;
+            Name = $"Isla {value}";
+            OnPropertyChanged(nameof(Number));
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}
+
+// Model class for editable existing islands
+public class EditableIsland : INotifyPropertyChanged
+{
+    private int _id;
+    private string _description;
+    private bool _isEditing;
+
+    public int Id
+    {
+        get => _id;
+        set
+        {
+            _id = value;
+            OnPropertyChanged(nameof(Id));
+        }
+    }
+
+    public string Description
+    {
+        get => _description;
+        set
+        {
+            _description = value;
+            OnPropertyChanged(nameof(Description));
+        }
+    }
+
+    public bool IsEditing
+    {
+        get => _isEditing;
+        set
+        {
+            _isEditing = value;
+            OnPropertyChanged(nameof(IsEditing));
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}
+
 public class IslandService : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler? PropertyChanged;
-    public ObservableCollection<IslandResponse> IslandList { get; set; } = [];
+    public ObservableCollection<EditableIsland> IslandList { get; set; } = [];
+    public ObservableCollection<EditablePendingIsland> PendingIslands { get; set; } = [];
 
     private string? _authToken;
-
     private IslandRequest Request { get; set; }
     private IslandModel _island;
 
@@ -27,6 +107,18 @@ public class IslandService : INotifyPropertyChanged
         {
             _island = value;
             OnPropertyChanged(nameof(Island));
+        }
+    }
+
+    private int _numberOfIslands = 0;
+    public int NumberOfIslands
+    {
+        get => _numberOfIslands;
+        set
+        {
+            _numberOfIslands = value;
+            OnPropertyChanged(nameof(NumberOfIslands));
+            GeneratePendingIslands();
         }
     }
 
@@ -41,9 +133,22 @@ public class IslandService : INotifyPropertyChanged
         }
     }
 
+    // Property for the islands counter
+    public int TotalIslandsCreated => IslandList.Count;
+
+    // Property for displaying counter text with emoji and formatting
+    public string IslandCounterText => $"📊 Total de Islas:";
 
     public ICommand GetByIdIslandDataCommand { get; }
     public ICommand SaveIslandDataCommand { get; }
+    public ICommand SaveAllIslandsCommand { get; }
+    public ICommand RemoveIslandCommand { get; }
+    public ICommand ClearAllIslandsCommand { get; }
+    public ICommand AddSingleIslandCommand { get; }
+    public ICommand EditIslandCommand { get; }
+    public ICommand SaveEditIslandCommand { get; }
+    public ICommand CancelEditIslandCommand { get; }
+    public ICommand DeleteIslandCommand { get; }
 
     public IslandService()
     {
@@ -51,6 +156,306 @@ public class IslandService : INotifyPropertyChanged
 
         GetByIdIslandDataCommand = new Command<int>(async (islandId) => await GetByIdIslandDataAsync(islandId));
         SaveIslandDataCommand = new Command(async () => await SaveIslandDataAsync());
+        SaveAllIslandsCommand = new Command(async () => await SaveAllIslandsAsync());
+        RemoveIslandCommand = new Command<EditablePendingIsland>(RemoveIsland);
+        ClearAllIslandsCommand = new Command(ClearAllIslands);
+        AddSingleIslandCommand = new Command(AddSingleIsland);
+        EditIslandCommand = new Command<EditableIsland>(EditIsland);
+        SaveEditIslandCommand = new Command<EditableIsland>(async (island) => await SaveEditIslandAsync(island));
+        CancelEditIslandCommand = new Command<EditableIsland>(CancelEditIsland);
+        DeleteIslandCommand = new Command<EditableIsland>(async (island) => await DeleteIslandAsync(island));
+
+        // Load existing islands first, then generate pending islands
+        _ = Task.Run(async () => 
+        {
+            await GetIslandAsync();
+            GeneratePendingIslands();
+        });
+    }
+
+    private void EditIsland(EditableIsland island)
+    {
+        // Cancel any other editing
+        foreach (var item in IslandList)
+        {
+            if (item != island)
+                item.IsEditing = false;
+        }
+        
+        island.IsEditing = true;
+    }
+
+    private void CancelEditIsland(EditableIsland island)
+    {
+        island.IsEditing = false;
+        // Reload original data to cancel changes
+        _ = Task.Run(async () => await GetIslandAsync());
+    }
+
+    private async Task SaveEditIslandAsync(EditableIsland island)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(island.Description))
+            {
+                await Application.Current.MainPage.DisplayAlert("Error", "La descripción no puede estar vacía.", "OK");
+                return;
+            }
+
+            var updateModel = new IslandModel
+            {
+                Description = island.Description
+            };
+
+            var updateRequest = new IslandRequest
+            {
+                Request = updateModel
+            };
+
+            using var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
+            var json = JsonSerializer.Serialize(updateRequest, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            var response = await httpClient.PutAsync($"{Configuration.BaseUrl}/api/v1/island/{island.Id}", content);
+
+            if (response.IsSuccessStatusCode)
+            {
+                await Application.Current.MainPage.DisplayAlert("Éxito", "Isla actualizada correctamente", "OK");
+                island.IsEditing = false;
+                await GetIslandAsync();
+                GeneratePendingIslands();
+            }
+            else
+            {
+                var error = await response.Content.ReadAsStringAsync();
+                await Application.Current.MainPage.DisplayAlert("Error", $"No se pudo actualizar la isla: {response.StatusCode}\n{error}", "OK");
+            }
+        }
+        catch (Exception ex)
+        {
+            await Application.Current.MainPage.DisplayAlert("Error", $"Error al actualizar la isla: {ex.Message}", "OK");
+        }
+    }
+
+    private async Task DeleteIslandAsync(EditableIsland island)
+    {
+        try
+        {
+            bool confirm = await Application.Current.MainPage.DisplayAlert("Confirmar", 
+                $"¿Desea eliminar la isla '{island.Description}'?", "Sí", "No");
+            
+            if (!confirm)
+                return;
+
+            using var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
+            var response = await httpClient.DeleteAsync($"{Configuration.BaseUrl}/api/v1/island/{island.Id}");
+
+            if (response.IsSuccessStatusCode)
+            {
+                await Application.Current.MainPage.DisplayAlert("Éxito", "Isla eliminada correctamente", "OK");
+                await GetIslandAsync();
+                GeneratePendingIslands();
+            }
+            else
+            {
+                var error = await response.Content.ReadAsStringAsync();
+                await Application.Current.MainPage.DisplayAlert("Error", $"No se pudo eliminar la isla: {response.StatusCode}\n{error}", "OK");
+            }
+        }
+        catch (Exception ex)
+        {
+            await Application.Current.MainPage.DisplayAlert("Error", $"Error al eliminar la isla: {ex.Message}", "OK");
+        }
+    }
+
+    private void GeneratePendingIslands()
+    {
+        PendingIslands.Clear();
+        
+        if (NumberOfIslands <= 0)
+        {
+            return;
+        }
+
+        int lastNumber = GetLastIslandNumber();
+        
+        for (int i = 1; i <= NumberOfIslands; i++)
+        {
+            int newNumber = lastNumber + i;
+            PendingIslands.Add(new EditablePendingIsland 
+            { 
+                Number = newNumber 
+            });
+        }
+    }
+
+    private int GetLastIslandNumber()
+    {
+        if (!IslandList.Any())
+        {
+            return 0;
+        }
+
+        int maxNumber = 0;
+        foreach (var island in IslandList)
+        {
+            if (island.Description.StartsWith("Isla "))
+            {
+                string numberPart = island.Description.Substring(5);
+                if (int.TryParse(numberPart, out int number))
+                {
+                    maxNumber = Math.Max(maxNumber, number);
+                }
+            }
+        }
+        
+        return maxNumber;
+    }
+
+    private void RemoveIsland(EditablePendingIsland island)
+    {
+        if (PendingIslands.Contains(island))
+        {
+            PendingIslands.Remove(island);
+        }
+    }
+
+    private void AddSingleIsland()
+    {
+        int nextNumber = GetLastIslandNumber();
+        if (PendingIslands.Any())
+        {
+            nextNumber = Math.Max(nextNumber, PendingIslands.Max(p => p.Number));
+        }
+        nextNumber++;
+
+        PendingIslands.Add(new EditablePendingIsland 
+        { 
+            Number = nextNumber 
+        });
+    }
+
+    private void ClearAllIslands()
+    {
+        PendingIslands.Clear();
+    }
+
+    private void ClearForm()
+    {
+        NumberOfIslands = 0;
+        Description = string.Empty;
+        PendingIslands.Clear();
+    }
+
+    private void UpdateCounterProperties()
+    {
+        OnPropertyChanged(nameof(TotalIslandsCreated));
+        OnPropertyChanged(nameof(IslandCounterText));
+    }
+
+    public async Task SaveAllIslandsAsync()
+    {
+        try
+        {
+            if (!PendingIslands.Any())
+            {
+                await Application.Current.MainPage.DisplayAlert("Error", "No hay islas para crear.", "OK");
+                return;
+            }
+
+            // Check for duplicate numbers
+            var duplicates = PendingIslands.GroupBy(x => x.Number)
+                                          .Where(g => g.Count() > 1)
+                                          .Select(x => x.Key);
+
+            if (duplicates.Any())
+            {
+                await Application.Current.MainPage.DisplayAlert("Error", 
+                    $"Hay números duplicados: {string.Join(", ", duplicates)}. Por favor, corrija antes de continuar.", "OK");
+                return;
+            }
+
+            // Check for conflicts with existing islands
+            var existingNumbers = IslandList.Where(i => i.Description.StartsWith("Isla "))
+                                           .Select(i => 
+                                           {
+                                               if (int.TryParse(i.Description.Substring(5), out int num))
+                                                   return num;
+                                               return -1;
+                                           })
+                                           .Where(n => n > 0);
+
+            var conflicts = PendingIslands.Where(p => existingNumbers.Contains(p.Number))
+                                         .Select(p => p.Number);
+
+            if (conflicts.Any())
+            {
+                bool confirm = await Application.Current.MainPage.DisplayAlert("Conflicto", 
+                    $"Las siguientes islas ya existen: {string.Join(", ", conflicts.Select(n => $"Isla {n}"))}. ¿Desea continuar de todas formas?", 
+                    "Sí", "No");
+                
+                if (!confirm)
+                    return;
+            }
+
+            using var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
+
+            int successCount = 0;
+            int totalCount = PendingIslands.Count;
+
+            foreach (var pendingIsland in PendingIslands.ToList())
+            {
+                try
+                {
+                    Island = new IslandModel
+                    {
+                        Description = pendingIsland.Name
+                    };
+
+                    Request = new IslandRequest
+                    {
+                        Request = Island
+                    };
+
+                    var json = JsonSerializer.Serialize(Request, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+                    var content = new StringContent(json, Encoding.UTF8, "application/json");
+                    var response = await httpClient.PostAsync($"{Configuration.BaseUrl}/api/v1/island", content);
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        successCount++;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Error creando isla {pendingIsland.Name}: {ex.Message}");
+                }
+            }
+
+            if (successCount == totalCount)
+            {
+                await Application.Current.MainPage.DisplayAlert("Éxito", $"Se crearon {successCount} islas correctamente", "OK");
+                ClearForm();
+                await GetIslandAsync();
+                GeneratePendingIslands();
+            }
+            else if (successCount > 0)
+            {
+                await Application.Current.MainPage.DisplayAlert("Parcial", $"Se crearon {successCount} de {totalCount} islas", "OK");
+                await GetIslandAsync();
+                GeneratePendingIslands();
+            }
+            else
+            {
+                await Application.Current.MainPage.DisplayAlert("Error", "No se pudieron crear las islas", "OK");
+            }
+        }
+        catch (Exception ex)
+        {
+            await Application.Current.MainPage.DisplayAlert("Error", $"Error al crear las islas: {ex.Message}", "OK");
+        }
     }
 
     public async Task GetByIdIslandDataAsync(int islandId)
@@ -100,7 +505,9 @@ public class IslandService : INotifyPropertyChanged
             if (response.IsSuccessStatusCode)
             {
                 await Application.Current.MainPage.DisplayAlert("Éxito", "Datos enviados correctamente", "OK");
+                Description = string.Empty;
                 await GetIslandAsync();
+                GeneratePendingIslands();
             }
             else
             {
@@ -127,10 +534,20 @@ public class IslandService : INotifyPropertyChanged
             });
 
             IslandList.Clear();
-            foreach (var island in islands.Data)
+            if (islands?.Data != null)
             {
-                IslandList.Add(island);
+                foreach (var island in islands.Data)
+                {
+                    IslandList.Add(new EditableIsland
+                    {
+                        Id = island.Idisland,
+                        Description = island.Description,
+                        IsEditing = false
+                    });
+                }
             }
+            
+            UpdateCounterProperties();
         }
         catch (Exception ex)
         {

--- a/APP.Eds/APP.Eds/UsesCases/Island/IslandPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Island/IslandPostView.xaml
@@ -2,46 +2,338 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="APP.Eds.UsesCases.Island.IslandPostView"
-             Title="Gestión De Isla">
+             Title="Gestión De Isla"
+             BackgroundColor="#F8F9FA">
 
-    <ScrollView>
-        <VerticalStackLayout Padding="20" Spacing="15">
+    <Grid>
+        <!-- Main Content -->
+        <ScrollView Grid.Row="1" BackgroundColor="White">
+            <VerticalStackLayout Padding="20" Spacing="15">
 
-            <Label FontSize="16" Text="Descripción" />
-            <Entry
-                Keyboard="Text"
-                Placeholder="Ingrese la descripción"
-                Text="{Binding Description, Mode=TwoWay}"
-                AutomationId="EntryDescription"/>
+                <!-- Counter Section -->
+                <Frame BackgroundColor="#E8F5E8" 
+                       BorderColor="#4CAF50" 
+                       CornerRadius="15" 
+                       Padding="20"
+                       Margin="0,5">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        
+                        <Label Grid.Column="0"
+                               Text="{Binding IslandCounterText}"
+                               FontSize="18"
+                               FontAttributes="Bold"
+                               TextColor="#2E7D32"
+                               VerticalOptions="Center" />
+                        
+                        <Frame Grid.Column="1"
+                               BackgroundColor="#4CAF50"
+                               CornerRadius="20"
+                               Padding="10,5"
+                               HasShadow="True">
+                            <Label Text="{Binding TotalIslandsCreated}"
+                                   FontSize="24"
+                                   FontAttributes="Bold"
+                                   TextColor="White"
+                                   HorizontalOptions="Center"
+                                   VerticalOptions="Center"
+                                   />
+                        </Frame>
+                    </Grid>
+                </Frame>
 
-            <Button
-                BackgroundColor="Green"
-                CornerRadius="10"
-                Text="Enviar Datos"
-                TextColor="White"
-                Command="{Binding SaveIslandDataCommand}"
-                AutomationId="ButtonSaveData"/>
+                <!-- Create Islands Section -->
+                <Frame BackgroundColor="White" BorderColor="#E0E0E0" CornerRadius="10" Padding="20">
+                    <StackLayout Spacing="10">
+                        <Label Text="📊 Crear Islas en Lote" 
+                               FontSize="16" 
+                               TextColor="#673AB7" 
+                               FontAttributes="Bold" />
+                        
+                        <Label Text="Número de Islas" FontSize="14" TextColor="#333" />
+                        
+                        <Entry x:Name="NumberEntry"
+                               Keyboard="Numeric"
+                               Placeholder="Ingrese el número de islas (0 para ninguna)"
+                               Text="{Binding NumberOfIslands, Mode=TwoWay}"
+                               BackgroundColor="White"
+                               HeightRequest="50"
+                               AutomationId="EntryNumberOfIslands"/>
 
-            <Label FontSize="18" Text="Lista de Islas" />
+                        <Button Text="🚀 Crear Todas las Islas"
+                                BackgroundColor="#4CAF50"
+                                TextColor="White"
+                                FontSize="16"
+                                FontAttributes="Bold"
+                                CornerRadius="25"
+                                HeightRequest="50"
+                                Command="{Binding SaveAllIslandsCommand}"
+                                AutomationId="ButtonSaveAllIslands"/>
+                    </StackLayout>
+                </Frame>
 
-            <CollectionView ItemsSource="{Binding IslandList}" Margin="0,20"
-                            AutomationId="CollectionViewIslandList">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate>
-                        <Grid Padding="10">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                            </Grid.RowDefinitions>
-                            <Label Text="ID:" FontSize="14" Grid.Row="0" />
-                            <Label Text="{Binding Id}" FontSize="14" Grid.Row="0" Margin="40,0,0,0"/>
-                            <Label Text="Descripción:" FontSize="14" Grid.Row="1" />
-                            <Label Text="{Binding Description}" FontSize="14" Grid.Row="1" Margin="40,0,0,0"/>
+                <!-- Pending Islands -->
+                <Frame BackgroundColor="White" BorderColor="#E0E0E0" CornerRadius="10" Padding="20">
+                    <StackLayout Spacing="10">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            
+                            <Label Grid.Column="0" 
+                                   Text="📝 Lista de Islas a Crear" 
+                                   FontSize="16" 
+                                   TextColor="#FF9800"
+                                   FontAttributes="Bold" />
+                            
+                            <Button Grid.Column="1"
+                                    Text="+"
+                                    BackgroundColor="#2196F3"
+                                    TextColor="White"
+                                    FontSize="16"
+                                    FontAttributes="Bold"
+                                    CornerRadius="15"
+                                    HeightRequest="36"
+                                    Padding="16,8"
+                                    Command="{Binding AddSingleIslandCommand}"
+                                    AutomationId="ButtonAddIsland"
+                                    Margin="5,0" />
+                            
+                            <Button Grid.Column="2"
+                                    Text="Limpiar"
+                                    BackgroundColor="#FF5722"
+                                    TextColor="White"
+                                    FontSize="15"
+                                    CornerRadius="15"
+                                    HeightRequest="36"
+                                    Padding="16,8"
+                                    Command="{Binding ClearAllIslandsCommand}"
+                                    AutomationId="ButtonClearAll"
+                                    Margin="5,0" />
                         </Grid>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
 
-        </VerticalStackLayout>
-    </ScrollView>
+                        <CollectionView ItemsSource="{Binding PendingIslands}" AutomationId="CollectionViewPendingIslands">
+                            <CollectionView.EmptyView>
+                                <Label Text="💡 Ingrese un número mayor a 0 para ver las islas a crear o presione + para agregar una isla individual" 
+                                       FontSize="14" 
+                                       TextColor="#999" 
+                                       HorizontalOptions="Center"
+                                       Margin="20" />
+                            </CollectionView.EmptyView>
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid BackgroundColor="#E3F2FD" Padding="15,10" Margin="0,2">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="80" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        
+                                        <Label Grid.Column="0" 
+                                               Text="🏝️" 
+                                               FontSize="16" 
+                                               VerticalOptions="Center"
+                                               Margin="0,0,10,0" />
+                                        
+                                        <Frame Grid.Column="1" 
+                                               BackgroundColor="White" 
+                                               CornerRadius="5"
+                                               Padding="5"
+                                               HasShadow="False">
+                                            <Entry Text="{Binding Number, Mode=TwoWay}"
+                                                   Keyboard="Numeric"
+                                                   FontSize="14"
+                                                   HorizontalOptions="Fill"
+                                                   VerticalOptions="Center"
+                                                   BackgroundColor="Transparent"
+                                                   Placeholder="Núm"
+                                                   AutomationId="EntryIslandNumber" />
+                                        </Frame>
+                                        
+                                        <Label Grid.Column="2" 
+                                               Text="{Binding Name}" 
+                                               FontSize="16" 
+                                               TextColor="#1976D2"
+                                               FontAttributes="Bold"
+                                               VerticalOptions="Center"
+                                               Margin="10,0,0,0" />
+                                        
+                                        <Button Grid.Column="3"
+                                                Text="✕"
+                                                BackgroundColor="#FF5722"
+                                                TextColor="White"
+                                                FontSize="12"
+                                                CornerRadius="15"
+                                                HeightRequest="37"
+                                                WidthRequest="40"
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveIslandCommand}"
+                                                CommandParameter="{Binding .}"
+                                                AutomationId="ButtonRemoveIsland" />
+                                    </Grid>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </StackLayout>
+                </Frame>
+
+                <!-- Created Islands -->
+                <Frame BackgroundColor="White" BorderColor="#E0E0E0" CornerRadius="10" Padding="20">
+                    <StackLayout Spacing="10">
+                        <Label Text="✅ Islas Creadas" 
+                               FontSize="16" 
+                               TextColor="#4CAF50"
+                               FontAttributes="Bold" />
+
+                        <CollectionView ItemsSource="{Binding IslandList}" AutomationId="CollectionViewIslandList">
+                            <CollectionView.EmptyView>
+                                <Label Text="📝 No hay islas creadas aún" 
+                                       FontSize="14" 
+                                       TextColor="#999" 
+                                       HorizontalOptions="Center"
+                                       Margin="20" />
+                            </CollectionView.EmptyView>
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid BackgroundColor="#E8F5E8" Padding="15,10" Margin="0,3">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        
+                                        
+                                        <!-- Description Row -->
+                                        <Label Text="Descripción:" 
+                                               FontSize="14" 
+                                               FontAttributes="Bold"
+                                               TextColor="#2E7D32"
+                                               Grid.Row="1" 
+                                               Grid.Column="0" />
+                                        
+                                        <!-- Content for description - either label or entry -->
+                                        <StackLayout Grid.Row="1" 
+                                                   Grid.Column="1" 
+                                                   Margin="10,0,0,0">
+                                            
+                                            <!-- Show Label when not editing -->
+                                            <Label Text="{Binding Description}" 
+                                                   FontSize="14" 
+                                                   TextColor="#333"
+                                                   VerticalOptions="Center"
+                                                   HorizontalOptions="StartAndExpand">
+                                                <Label.Triggers>
+                                                    <DataTrigger TargetType="Label" Binding="{Binding IsEditing}" Value="True">
+                                                        <Setter Property="IsVisible" Value="False" />
+                                                    </DataTrigger>
+                                                </Label.Triggers>
+                                            </Label>
+                                            
+                                            <!-- Show Entry when editing -->
+                                            <Entry Text="{Binding Description, Mode=TwoWay}" 
+                                                   FontSize="14" 
+                                                   BackgroundColor="White"
+                                                   IsVisible="False"
+                                                   AutomationId="EntryEditDescription">
+                                                <Entry.Triggers>
+                                                    <DataTrigger TargetType="Entry" Binding="{Binding IsEditing}" Value="True">
+                                                        <Setter Property="IsVisible" Value="True" />
+                                                    </DataTrigger>
+                                                </Entry.Triggers>
+                                            </Entry>
+                                        </StackLayout>
+                                        
+                                        <!-- Action Buttons Row -->
+                                        <StackLayout Grid.Row="2" 
+                                                   Grid.Column="0" 
+                                                   Grid.ColumnSpan="2" 
+                                                   Orientation="Horizontal" 
+                                                   HorizontalOptions="End"
+                                                   Margin="0,10,0,0">
+                                            
+                                            <!-- Edit Mode Buttons -->
+                                            <StackLayout Orientation="Horizontal" IsVisible="False">
+                                                <StackLayout.Triggers>
+                                                    <DataTrigger TargetType="StackLayout" Binding="{Binding IsEditing}" Value="True">
+                                                        <Setter Property="IsVisible" Value="True" />
+                                                    </DataTrigger>
+                                                </StackLayout.Triggers>
+                                                
+                                                <Button Text="💾"
+                                                        BackgroundColor="#4CAF50"
+                                                        TextColor="White"
+                                                        FontSize="14"
+                                                        CornerRadius="15"
+                                                        HeightRequest="40"
+                                                        WidthRequest="45"
+                                                        Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.SaveEditIslandCommand}"
+                                                        CommandParameter="{Binding .}"
+                                                        AutomationId="ButtonSaveEdit"
+                                                        Margin="5,0" />
+                                                
+                                                <Button Text="❌"
+                                                        BackgroundColor="#757575"
+                                                        TextColor="White"
+                                                        FontSize="14"
+                                                        CornerRadius="15"
+                                                        HeightRequest="40"
+                                                        WidthRequest="45"
+                                                        Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.CancelEditIslandCommand}"
+                                                        CommandParameter="{Binding .}"
+                                                        AutomationId="ButtonCancelEdit"
+                                                        Margin="5,0" />
+                                            </StackLayout>
+                                            
+                                            <!-- Normal Mode Buttons -->
+                                            <StackLayout Orientation="Horizontal">
+                                                <StackLayout.Triggers>
+                                                    <DataTrigger TargetType="StackLayout" Binding="{Binding IsEditing}" Value="True">
+                                                        <Setter Property="IsVisible" Value="False" />
+                                                    </DataTrigger>
+                                                </StackLayout.Triggers>
+                                                
+                                                <Button Text="✏️"
+                                                        BackgroundColor="#2196F3"
+                                                        TextColor="White"
+                                                        FontSize="14"
+                                                        CornerRadius="15"
+                                                        HeightRequest="40"
+                                                        WidthRequest="45"
+                                                        Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.EditIslandCommand}"
+                                                        CommandParameter="{Binding .}"
+                                                        AutomationId="ButtonEditIsland"
+                                                        Margin="5,0" />
+                                                
+                                                <Button Text="🗑️"
+                                                        BackgroundColor="#FF5722"
+                                                        TextColor="White"
+                                                        FontSize="14"
+                                                        CornerRadius="15"
+                                                        HeightRequest="40"
+                                                        WidthRequest="45"
+                                                        Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.DeleteIslandCommand}"
+                                                        CommandParameter="{Binding .}"
+                                                        AutomationId="ButtonDeleteIsland"
+                                                        Margin="5,0" />
+                                            </StackLayout>
+                                        </StackLayout>
+                                    </Grid>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </StackLayout>
+                </Frame>
+
+            </VerticalStackLayout>
+        </ScrollView>
+    </Grid>
 </ContentPage>

--- a/APP.Eds/APP.Eds/UsesCases/Island/IslandPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Island/IslandPostView.xaml.cs
@@ -5,11 +5,35 @@ namespace APP.Eds.UsesCases.Island;
 public partial class IslandPostView : ContentPage
 {
     private IslandService _islandService;
+    
     public IslandPostView()
     {
         InitializeComponent();
         _islandService = new IslandService();
         BindingContext = _islandService;
+    }
+
+    private async void OnBackButtonClicked(object sender, EventArgs e)
+    {
+        try
+        {
+            await Navigation.PopAsync();
+        }
+        catch (Exception ex)
+        {
+            await DisplayAlert("Error", $"Error al navegar: {ex.Message}", "OK");
+        }
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        
+        // Refresh islands list when page appears
+        if (_islandService != null)
+        {
+            await _islandService.GetIslandAsync();
+        }
     }
 
     private async void Button_Clicked_1(object sender, EventArgs e)


### PR DESCRIPTION
## Summary by Sourcery

Redesign island management by introducing editable models and a pending islands workflow in IslandService, adding commands for batch and individual island operations, implementing reactive counters, and updating the UI for navigation and data refresh

New Features:
- Introduce EditablePendingIsland and EditableIsland classes to enable in-place editing and pending island creation
- Add batch creation workflow with pending islands list, duplicate checks, and conflict confirmation
- Add commands for adding/removing/clearing pending islands and editing/saving/canceling/deleting existing islands
- Expose reactive properties for number of islands, total island count, and formatted counter text
- Enhance IslandPostView with a back button handler and data refresh on page appearing

Enhancements:
- Refactor IslandService to use ObservableCollection<EditableIsland> and PendingIslands for reactive UI binding
- Update island fetching logic to wrap responses in EditableIsland and update counter properties automatically