### PR TITLE
fix (Court): fix popup ok

### DIFF
--- a/APP.Eds/APP.Eds/Components/PopUp/AddCourtExpenditure.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddCourtExpenditure.xaml.cs
@@ -18,8 +18,18 @@ public partial class AddCourtExpenditure : Popup
 
     private void OnCloseTapped(object sender, EventArgs e)
     {
-        Close();
-
+        try
+        {
+            Close();
+        }
+        catch (ObjectDisposedException ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"AddCourtExpenditure popup was already disposed during close: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error closing AddCourtExpenditure popup: {ex.Message}");
+        }
     }
 
     private async void Add_Expenditure(object sender, EventArgs e)
@@ -43,6 +53,26 @@ public partial class AddCourtExpenditure : Popup
         FirstEntry.IsEnabled = false;
         SecondEntry.IsEnabled = false;
         await CloseAsync();
+    }
+
+    private async Task CloseAsync()
+    {
+        try
+        {
+            await Task.Delay(100);
+            try
+            {
+                Close();
+            }
+            catch (ObjectDisposedException ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"AddCourtExpenditure popup was already disposed during async close: {ex.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error in AddCourtExpenditure CloseAsync: {ex.Message}");
+        }
     }
 
     private void ExpenditureSelected(object sender, EventArgs e)

--- a/APP.Eds/APP.Eds/Components/PopUp/AddInfo.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddInfo.xaml.cs
@@ -15,7 +15,18 @@ public partial class AddInfo : Popup
 
     private void OnCloseTapped(object sender, EventArgs e)
     {
-        Close();
+        try
+        {
+            Close();
+        }
+        catch (ObjectDisposedException ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"AddInfo popup was already disposed during close: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error closing AddInfo popup: {ex.Message}");
+        }
     }
 
     private async void OnSaveTapped(object sender, EventArgs e)
@@ -25,11 +36,26 @@ public partial class AddInfo : Popup
         if (editor != null && !string.IsNullOrWhiteSpace(editor.Text))
         {
             await courtService.SaveAdditionalInfoAsync(editor.Text);
-            Close();
+            
+            try
+            {
+                Close();
+            }
+            catch (ObjectDisposedException ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"AddInfo popup was disposed after saving: {ex.Message}");
+            }
         }
         else
         {
-            Close();
+            try
+            {
+                Close();
+            }
+            catch (ObjectDisposedException ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"AddInfo popup was disposed without saving: {ex.Message}");
+            }
         }
     }
 }

--- a/APP.Eds/APP.Eds/Components/PopUp/AddShopping.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddShopping.xaml.cs
@@ -17,7 +17,18 @@ public partial class AddShopping : Popup
 
     private void OnCloseTapped(object sender, EventArgs e)
     {
-        Close();
+        try
+        {
+            Close();
+        }
+        catch (ObjectDisposedException ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"AddShopping popup was already disposed during close: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error closing AddShopping popup: {ex.Message}");
+        }
     }
 
     private ShoppingService GetShoppingService()
@@ -98,7 +109,14 @@ public partial class AddShopping : Popup
             // Show professional success feedback
             await CustomAlert.ShowSuccessAsync($"Producto agregado exitosamente a la compra\n\nCantidad: {vm.Quantity:F2} galones\nValor total: ${(vm.Quantity * vm.Price):F2}", "Producto Agregado");
 
-            Close();
+            try
+            {
+                Close();
+            }
+            catch (ObjectDisposedException ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"AddShopping popup was disposed after operation: {ex.Message}");
+            }
         }
         finally
         {

--- a/APP.Eds/APP.Eds/Components/PopUp/Category.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/Category.xaml.cs
@@ -60,40 +60,65 @@ namespace APP.Eds.Views.Popups
 
         private async void OnCloseTapped(object sender, EventArgs e)
         {
-            await AnimateExit();
-            Close();
+            try
+            {
+                await AnimateExit();                
+                try
+                {
+                    Close();
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"CategoryPopup was already disposed during close: {ex.Message}");
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error in CategoryPopup OnCloseTapped: {ex.Message}");
+            }
         }
 
         private async void OnMenuItemClicked(object sender, EventArgs e)
         {
-            // Feedback táctil en dispositivos móviles
             try
             {
-#if ANDROID || IOS
-                HapticFeedback.Perform(HapticFeedbackType.Click);
-#endif
-            }
-            catch { } // Ignorar errores de feedback táctil
-            
-            // Animar el elemento clickeado con efecto más pronunciado
-            if (sender is Border border)
-            {
-                _ = Task.Run(async () =>
+                try
                 {
-                    await MainThread.InvokeOnMainThreadAsync(async () =>
+#if ANDROID || IOS
+                    HapticFeedback.Perform(HapticFeedbackType.Click);
+#endif
+                }
+                catch { }
+                
+                if (sender is Border border)
+                {
+                    _ = Task.Run(async () =>
                     {
-                        // Crear un efecto de "pulso"
-                        await border.ScaleTo(0.92, 80, Easing.CubicOut);
-                        await border.ScaleTo(1.02, 80, Easing.CubicOut);
-                        await border.ScaleTo(1, 80, Easing.CubicOut);
+                        await MainThread.InvokeOnMainThreadAsync(async () =>
+                        {
+                            // Crear un efecto de "pulso"
+                            await border.ScaleTo(0.92, 80, Easing.CubicOut);
+                            await border.ScaleTo(1.02, 80, Easing.CubicOut);
+                            await border.ScaleTo(1, 80, Easing.CubicOut);
+                        });
                     });
-                });
+                }
+
+                await Task.Delay(180);
+                await AnimateExit();
+                try
+                {
+                    Close();
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"CategoryPopup was already disposed during menu item close: {ex.Message}");
+                }
             }
-            
-            // Pequeña pausa para mostrar la animación
-            await Task.Delay(180);
-            await AnimateExit();
-            Close();
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error in CategoryPopup OnMenuItemClicked: {ex.Message}");
+            }
         }
 
         private async Task AnimateExit()

--- a/APP.Eds/APP.Eds/Components/PopUp/CustomAlert.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/CustomAlert.xaml.cs
@@ -134,12 +134,29 @@ public partial class CustomAlert : Popup
     {
         try
         {
-            Application.Current?.MainPage?.ShowPopup(this);
+            _ = MainThread.InvokeOnMainThreadAsync(async () =>
+            {
+                try
+                {
+                    Application.Current?.MainPage?.ShowPopup(this);
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    Debug.WriteLine($"CustomAlert was disposed during show: {ex.Message}");
+                    _taskCompletionSource?.TrySetResult(false);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Error showing CustomAlert: {ex.Message}");
+                    _taskCompletionSource?.TrySetResult(false);
+                }
+            });
+            
             return _taskCompletionSource.Task;
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error showing custom alert: {ex.Message}");
+            Debug.WriteLine($"Error in CustomAlert.ShowAsync: {ex.Message}");
             _taskCompletionSource?.TrySetResult(false);
             return _taskCompletionSource.Task;
         }
@@ -149,8 +166,18 @@ public partial class CustomAlert : Popup
     {
         try
         {
-            await Task.Delay(100); // Small delay for smooth animation
-            Close();
+            await MainThread.InvokeOnMainThreadAsync(async () =>
+            {
+                await Task.Delay(100); 
+                try
+                {
+                    Close();
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    Debug.WriteLine($"CustomAlert was already disposed during close: {ex.Message}");
+                }
+            });
         }
         catch (Exception ex)
         {
@@ -158,7 +185,6 @@ public partial class CustomAlert : Popup
         }
     }
 
-    // Static helper methods for easy usage
     public static async Task ShowErrorAsync(string message, string title = "Error")
     {
         var alert = new CustomAlert(title, message, "OK", null, AlertType.Error);

--- a/APP.Eds/APP.Eds/Services/Navigation/MainService.cs
+++ b/APP.Eds/APP.Eds/Services/Navigation/MainService.cs
@@ -24,6 +24,7 @@ using APP.Eds.Views.Popups;
 using CommunityToolkit.Maui.Views;
 using System.Collections.ObjectModel;
 using System.Windows.Input;
+using System.Diagnostics; 
 
 namespace APP.Eds.Services.Navigation
 {
@@ -128,10 +129,25 @@ namespace APP.Eds.Services.Navigation
                 Icon = icon;
                 Items = items;
                 IsDirectNavigation = false;
-                ShowPopupCommand = new Command(() =>
+                ShowPopupCommand = new Command(async () =>
                 {
+                    // ✅ CORREGIDO: Crear nueva instancia local en cada ejecución
                     var popup = new CategoryPopup(items, title);
-                    Application.Current?.MainPage?.ShowPopup(popup);
+                    await MainThread.InvokeOnMainThreadAsync(async () =>
+                    {
+                        try
+                        {
+                            await Application.Current.MainPage.ShowPopupAsync(popup);
+                        }
+                        catch (ObjectDisposedException ex)
+                        {
+                            Debug.WriteLine($"CategoryPopup was disposed: {ex.Message}");
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.WriteLine($"Error showing CategoryPopup: {ex.Message}");
+                        }
+                    });
                 });
             }
 
@@ -148,7 +164,7 @@ namespace APP.Eds.Services.Navigation
         public class MenuItemModel
         {
             public string Title { get; set; }
-            public string Name => Title; // Propiedad para compatibilidad con el popup
+            public string Name => Title; 
             public string Icon { get; set; }
             public Type PageType { get; set; }
             public ICommand NavigateCommand { get; }

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
@@ -734,7 +734,7 @@
                 <!-- Upload Document Button -->
                 <Grid Grid.Column="0" x:Name="DocumentButton">
                     <Grid.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="OnBottomNavTapped" CommandParameter="Document"/>
+                        <TapGestureRecognizer Tapped="OnDocumentTapped"/>
                     </Grid.GestureRecognizers>
                     
                     <!-- Background Circle -->
@@ -782,7 +782,7 @@
                 <!-- Add Expense Button -->
                 <Grid Grid.Column="1" x:Name="ExpenseButton">
                     <Grid.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="OnBottomNavTapped" CommandParameter="Expense"/>
+                        <TapGestureRecognizer Tapped="OnExpenseTapped"/>
                     </Grid.GestureRecognizers>
                     
                     <!-- Background Circle -->
@@ -829,7 +829,7 @@
                 <!-- Additional Info Button -->
                 <Grid Grid.Column="2" x:Name="InfoButton">
                     <Grid.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="OnBottomNavTapped" CommandParameter="Info"/>
+                        <TapGestureRecognizer Tapped="OnInfoTapped"/>
                     </Grid.GestureRecognizers>
                     
                     <!-- Background Circle -->
@@ -875,7 +875,7 @@
                 <!-- History/List Button -->
                 <Grid Grid.Column="3" x:Name="HistoryButton">
                     <Grid.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="OnBottomNavTapped" CommandParameter="History"/>
+                        <TapGestureRecognizer Tapped="OnHistoryTapped"/>
                     </Grid.GestureRecognizers>
                     
                     <!-- Background Circle -->

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
@@ -18,10 +18,6 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
     private CourtService _service;
     public string UserRole { get; set; } = string.Empty;
     
-    // Variables para rastrear popups activos
-    private Popup _activePopup;
-    private readonly SemaphoreSlim _popupSemaphore = new(1, 1);
-    
     // Propiedad para el elemento activo del menú
     private string _activeNavItem = "Document";
     public string ActiveNavItem 
@@ -158,8 +154,6 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
     protected override void OnDisappearing()
     {
         base.OnDisappearing();
-        // Cerrar cualquier popup activo cuando la página desaparezca
-        CloseActivePopupSafely();
     }
 
     private void ApplyConfig(Dictionary<string, bool> config)
@@ -175,27 +169,92 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
     }
 
     /// <summary>
-    /// Maneja los taps en el menú de navegación inferior
+    /// Métodos específicos para cada botón del menú inferior
+    /// </summary>
+    private async void OnDocumentTapped(object sender, EventArgs e)
+    {
+        await HandleNavTap("Document");
+    }
+
+    private async void OnExpenseTapped(object sender, EventArgs e)
+    {
+        await HandleNavTap("Expense");
+    }
+
+    private async void OnInfoTapped(object sender, EventArgs e)
+    {
+        await HandleNavTap("Info");
+    }
+
+    private async void OnHistoryTapped(object sender, EventArgs e)
+    {
+        await HandleNavTap("History");
+    }
+
+    /// <summary>
+    /// Maneja los taps en el menú de navegación inferior (método centralizado)
+    /// </summary>
+    private async Task HandleNavTap(string navItem)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(navItem))
+            {
+                Debug.WriteLine("NavItem is null or empty");
+                return;
+            }
+
+            Debug.WriteLine($"Navigation tap: {navItem}");
+
+            ActiveNavItem = navItem;
+            
+            // Animar el tap
+            await AnimateNavItemTap(navItem);
+            
+            // Ejecutar la acción correspondiente
+            await ExecuteNavAction(navItem);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error in navigation tap for {navItem}: {ex.Message}");
+            await CustomAlert.ShowErrorAsync("No se pudo procesar la acción del menú", "Error de Navegación");
+        }
+    }
+
+    /// <summary>
+    /// Maneja los taps en el menú de navegación inferior (método original mantenido por compatibilidad)
     /// </summary>
     private async void OnBottomNavTapped(object sender, EventArgs e)
     {
-        if (sender is TapGestureRecognizer tapGesture && tapGesture.CommandParameter is string navItem)
+        try
         {
-            try
+            string navItem = null;
+            
+            if (sender is TapGestureRecognizer tapGesture && tapGesture.CommandParameter is string commandParam)
             {
-                // Actualizar elemento activo (esto desencadena las animaciones)
-                ActiveNavItem = navItem;
-                
-                // Animar el tap
-                await AnimateNavItemTap(navItem);
-                
-                // Ejecutar la acción correspondiente
-                await ExecuteNavAction(navItem);
+                navItem = commandParam;
             }
-            catch (Exception ex)
+            else if (sender is View viewElement && viewElement.GestureRecognizers.FirstOrDefault() is TapGestureRecognizer gesture && gesture.CommandParameter is string param)
             {
-                Debug.WriteLine($"Error in bottom nav tap: {ex.Message}");
+                navItem = param;
             }
+            else if (e is TappedEventArgs tappedArgs && tappedArgs.Parameter is string tappedParam)
+            {
+                navItem = tappedParam;
+            }
+
+            if (string.IsNullOrEmpty(navItem))
+            {
+                Debug.WriteLine("No se pudo determinar el elemento de navegación");
+                return;
+            }
+
+            await HandleNavTap(navItem);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error in bottom nav tap: {ex.Message}");
+            await CustomAlert.ShowErrorAsync("No se pudo procesar la acción del menú", "Error de Navegación");
         }
     }
 
@@ -342,85 +401,12 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
         }
     }
 
-    /// <summary>
-    /// Método seguro para mostrar popups que evita múltiples instancias simultáneas
-    /// </summary>
-    private async Task<bool> ShowPopupSafelyAsync(Popup popup)
-    {
-        if (!await _popupSemaphore.WaitAsync(100)) // Timeout de 100ms
-        {
-            popup?.Close(); // Cerrar el popup si no se puede mostrar
-            return false;
-        }
-
-        try
-        {
-            // Cerrar popup activo si existe
-            CloseActivePopupSafely();
-
-            // Configurar el nuevo popup
-            _activePopup = popup;
-
-            // Mostrar el popup de forma segura
-            await MainThread.InvokeOnMainThreadAsync(async () =>
-            {
-                try
-                {
-                    await this.ShowPopupAsync(popup);
-                }
-                catch (ObjectDisposedException)
-                {
-                    Debug.WriteLine("Popup was already disposed");
-                    _activePopup = null;
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine($"Error showing popup: {ex.Message}");
-                    _activePopup = null;
-                }
-            });
-
-            return true;
-        }
-        finally
-        {
-            _popupSemaphore.Release();
-        }
-    }
-
-    /// <summary>
-    /// Cierra el popup activo de forma segura
-    /// </summary>
-    private void CloseActivePopupSafely()
-    {
-        if (_activePopup != null)
-        {
-            try
-            {
-                _activePopup.Close();
-            }
-            catch (ObjectDisposedException)
-            {
-                // El popup ya fue dispuesto, esto es normal
-                Debug.WriteLine("Popup was already disposed when trying to close");
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"Error closing popup: {ex.Message}");
-            }
-            finally
-            {
-                _activePopup = null;
-            }
-        }
-    }
-
     private async Task OpenDocumentPopUp()
     {
         try
         {
             var popup = new AddDocuemt(_service);
-            await ShowPopupSafelyAsync(popup);
+            await ShowPopupSafelyAsync<object>(popup);
         }
         catch (Exception ex)
         {
@@ -434,7 +420,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
         try
         {
             var popup = new AddCourtExpenditure(_service);
-            await ShowPopupSafelyAsync(popup);
+            await ShowPopupSafelyAsync<object>(popup);
         }
         catch (Exception ex)
         {
@@ -448,7 +434,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
         try
         {
             var popup = new AddInfo(_service);
-            await ShowPopupSafelyAsync(popup);
+            await ShowPopupSafelyAsync<object>(popup);
         }
         catch (Exception ex)
         {
@@ -461,8 +447,6 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
     {
         try
         {
-            // Cerrar cualquier popup antes de navegar
-            CloseActivePopupSafely();
             await Navigation.PushAsync(new CourtListView());
         }
         catch (Exception ex)
@@ -478,7 +462,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
         try
         {
             var popup = new AddDispenser(_service);
-            await ShowPopupSafelyAsync(popup);
+            await ShowPopupSafelyAsync<object>(popup);
         }
         catch (Exception ex)
         {
@@ -492,7 +476,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
         try
         {
             var popup = new AddCourtTypeOfCollection(_service);
-            await ShowPopupSafelyAsync(popup);
+            await ShowPopupSafelyAsync<object>(popup);
         }
         catch (Exception ex)
         {
@@ -688,5 +672,36 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
     protected new virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    private static async Task<T> ShowPopupSafelyAsync<T>(Popup popup) where T : class
+    {
+        try
+        {
+            var result = await MainThread.InvokeOnMainThreadAsync(async () =>
+            {
+                try
+                {
+                    return await Application.Current.MainPage.ShowPopupAsync(popup) as T;
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    Debug.WriteLine($"Popup was disposed during show: {ex.Message}");
+                    return null;
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Error showing popup: {ex.Message}");
+                    return null;
+                }
+            });
+            
+            return result;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error in ShowPopupSafelyAsync: {ex.Message}");
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Simplify and centralize navigation handling and popup display, remove legacy concurrency code, and add robust exception handling to prevent disposed-popup errors

Bug Fixes:
- Prevent crashes from ObjectDisposedException when showing or closing popups by catching and logging exceptions
- Ensure CategoryModel.ShowPopupCommand creates a new popup instance per invocation to avoid reuse of disposed popups

Enhancements:
- Consolidate bottom navigation taps into specific handlers and a shared HandleNavTap method for consistent animation and action execution
- Replace manual popup tracking (SemaphoreSlim, active popup field) with a generic ShowPopupSafelyAsync<T> executed on the main thread
- Wrap Show and Close calls in all popup components and in CategoryModel.ShowPopupCommand in try-catch blocks to log ObjectDisposedException and other errors