### PR TITLE
refactor: (CourtList): time adjustment in lists of the court

### DIFF
--- a/APP.Eds/APP.Eds/App.xaml
+++ b/APP.Eds/APP.Eds/App.xaml
@@ -13,6 +13,7 @@
             
             <!-- Converters -->
             <converters:MenuIconConverter x:Key="MenuIconConverter" />
+            <converters:TimeSpanTo12HourConverter x:Key="TimeSpanTo12HourConverter" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/APP.Eds/APP.Eds/Components/PopUp/CourtDetailPopup.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/CourtDetailPopup.xaml
@@ -62,11 +62,11 @@
 
                         <Label Text="{Binding ShiftTranslation}" FontAttributes="Bold"  Grid.Row="3" Grid.Column="0" Margin="0,10,0,0"
                                AutomationId="LabelShift"/>
-                        <Label Text="{Binding Starttime}"  Grid.Row="4" Grid.Column="0"
+                        <Label Text="{Binding Starttime, Converter={StaticResource TimeSpanTo12HourConverter}}"  Grid.Row="4" Grid.Column="0"
                                AutomationId="LabelStarttime"/>
-                        <Label Text="{Binding Endtime}"  Grid.Row="4" Grid.Column="1" Margin="0,0,0,10"
+                        <Label Text="{Binding Endtime, Converter={StaticResource TimeSpanTo12HourConverter}}"  Grid.Row="4" Grid.Column="1" Margin="0,0,0,10"
                                AutomationId="LabelEndtime"/>
-                        
+
 
                         <!-- Totals -->
                         <Label Text="{Binding TotalsTranslation}" FontAttributes="Bold" FontSize="18"  Grid.Row="6" Grid.Column="0"

--- a/APP.Eds/APP.Eds/Converters/TimeSpanTo12HourConverter.cs
+++ b/APP.Eds/APP.Eds/Converters/TimeSpanTo12HourConverter.cs
@@ -1,0 +1,61 @@
+﻿using System.Globalization;
+using Microsoft.Maui.Controls;
+
+namespace APP.Eds.Converters;
+
+public class TimeSpanTo12HourConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is TimeSpan timeSpan)
+        {
+            DateTime dateTime = DateTime.Today.Add(timeSpan);
+            // Use Spanish culture for AM/PM formatting
+            var spanishCulture = new CultureInfo("es-CO");
+            return dateTime.ToString("h:mm tt", spanishCulture);
+        }
+
+        if (value is string timeString)
+        {
+            var spanishCulture = new CultureInfo("es-CO");
+
+            // Try parsing as TimeSpan first (format: HH:mm:ss)
+            if (TimeSpan.TryParse(timeString, out TimeSpan parsedTime))
+            {
+                DateTime dateTime = DateTime.Today.Add(parsedTime);
+                return dateTime.ToString("h:mm tt", spanishCulture);
+            }
+
+            // Try parsing as DateTime (in case the string is already a time format)
+            if (DateTime.TryParse(timeString, out DateTime parsedDateTime))
+            {
+                return parsedDateTime.ToString("h:mm tt", spanishCulture);
+            }
+
+            // If we can't parse it, try some common formats
+            string[] timeFormats = { "HH:mm:ss", "HH:mm", "H:mm:ss", "H:mm" };
+            foreach (string format in timeFormats)
+            {
+                if (DateTime.TryParseExact(timeString, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime result))
+                {
+                    return result.ToString("h:mm tt", spanishCulture);
+                }
+            }
+        }
+
+        return value?.ToString() ?? "";
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is string timeString)
+        {
+            var spanishCulture = new CultureInfo("es-CO");
+            if (DateTime.TryParseExact(timeString, "h:mm tt", spanishCulture, DateTimeStyles.None, out DateTime result))
+            {
+                return result.TimeOfDay;
+            }
+        }
+        return TimeSpan.Zero;
+    }
+}

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtListView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtListView.xaml
@@ -17,11 +17,11 @@
                             <Label Text="{Binding DateStarttime}"  Grid.Row="2" Grid.Column="3"/>
 
                             <Label Text="Inicio" FontAttributes="Bold" Grid.Row="3" Grid.Column="1"/>
-                            <Label Text="{Binding Starttime}"  Grid.Row="3" Grid.Column="3"/>
+                            <Label Text="{Binding Starttime, Converter={StaticResource TimeSpanTo12HourConverter}}"  Grid.Row="3" Grid.Column="3"/>
                             <BoxView Grid.Row="3" Grid.ColumnSpan="6" ZIndex="-1"/>
 
                             <Label Text="Fin"  FontAttributes="Bold" Grid.Row="4" Grid.Column="1"/>
-                            <Label Text="{Binding Endtime}"  Grid.Row="4" Grid.Column="3"/>
+                            <Label Text="{Binding Endtime, Converter={StaticResource TimeSpanTo12HourConverter}}"  Grid.Row="4" Grid.Column="3"/>
 
                             <Label Text="Total"  FontAttributes="Bold" Grid.Row="5" Grid.Column="1"/>
                             <Label Text="{Binding TotalAccumulatedAmount, StringFormat='$ {0:N3}'}"  Grid.Row="5" Grid.Column="3"/>


### PR DESCRIPTION
## Summary by Sourcery

Refactor court time displays to use a new 12-hour Spanish formatting converter.

Enhancements:
- Add TimeSpanTo12HourConverter to transform TimeSpan or time string inputs into "h:mm tt" format using the es-CO culture
- Integrate the TimeSpanTo12HourConverter into App.xaml, CourtDetailPopup.xaml, and CourtListView.xaml to standardize time rendering in court lists