### PR TITLE
fix: Bug TypeOfCollection: the bug#176 is corrected.

### DIFF
--- a/APP.Eds/APP.Eds/Components/PopUp/AddCourtTypeOfCollection.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddCourtTypeOfCollection.xaml.cs
@@ -293,7 +293,7 @@ public partial class AddCourtTypeOfCollection : Popup
             
             if (selected.Count == 0)
             {
-                await Application.Current.MainPage.DisplayAlert("Validación", 
+                await Application.Current.MainPage.DisplayAlert("Error", 
                     "Debe seleccionar al menos un método de pago.", "OK");
                 return;
             }
@@ -303,7 +303,7 @@ public partial class AddCourtTypeOfCollection : Popup
             {
                 if (p.Amount <= 0m)
                 {
-                    await Application.Current.MainPage.DisplayAlert("Validación",
+                    await Application.Current.MainPage.DisplayAlert("Error",
                         $"El monto para '{p.Type.Description}' debe ser mayor a 0.", "OK");
                     return;
                 }
@@ -315,14 +315,15 @@ public partial class AddCourtTypeOfCollection : Popup
             decimal dataNew = selected.Sum(p => p.Amount);
             decimal amountNew = totalSalesDay - addedNow - dataNew;
 
-            if (Math.Abs(amountNew) > 0.01m) // Allow for small rounding differences
+            if (Math.Abs(amountNew) > 0)
             {
-                bool confirm = await Application.Current.MainPage.DisplayAlert("Confirmación",
-                    $"El total del día no coincide exactamente (diferencia: ${amountNew:F2}).", 
-                    "Continuar", "Revisar");
-                
-                if (!confirm) return;
+                await Application.Current.MainPage.DisplayAlert("Error",
+                    $"El total de los métodos de pago seleccionados ({dataNew:C2}) no coincide con el total de la venta ({totalSalesDay:C2}).\n\n" +
+                    $"Diferencia: {amountNew:C2}", "OK");
+                return;
             }
+
+            
 
             // Add selected payment methods
             foreach (var p in selected)

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
@@ -534,7 +534,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
 
                 double cash = totalTypeOfCollection - totalExpenditures;
                 const double epsilon = 1e-6;
-                if (cash < -epsilon)
+                if (cash < epsilon)
                 {
                     await CustomAlert.ShowErrorAsync($"El total de efectivo no puede ser negativo.\n\nTotal recaudo: ${totalTypeOfCollection:F2}\nTotal gastos: ${totalExpenditures:F2}", "Error en Cálculos");
                     return;


### PR DESCRIPTION
## Summary by Sourcery

Fix validation logic and error messaging in payment collection workflows

Bug Fixes:
- Standardize dialog titles to “Error” for missing selection and non-positive payment amounts
- Enforce exact match of selected payment methods total against the sale total by showing an error instead of a confirmation prompt
- Adjust cash total validation to flag any non-positive balance (using an epsilon threshold) as an error in the court post view