### PR TITLE
Cierre turno ocultar secciones

### DIFF
--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
@@ -1,5 +1,6 @@
 <ContentPage
     x:Class="APP.Eds.UsesCases.Court.CourtPostView"
+    x:Name="CortePage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:sys="clr-namespace:System;assembly=netstandard"
@@ -18,7 +19,7 @@
     <AbsoluteLayout>
         <ScrollView AbsoluteLayout.LayoutBounds="0,0,1,1" AbsoluteLayout.LayoutFlags="All" x:Name="MainContent">
             <VerticalStackLayout Padding="16" Spacing="16">
-                
+
                 <!-- Header Card with Purple Gradient -->
                 <Border BackgroundColor="#6A1B9A" 
                         StrokeShape="RoundRectangle 16"
@@ -60,7 +61,7 @@
                                    TextColor="#2D3436"
                                    VerticalOptions="Center"/>
                         </StackLayout>
-                        
+
                         <Grid ColumnDefinitions="100, *" RowDefinitions="Auto,Auto,Auto" RowSpacing="16">
                             <!-- Business -->
                             <Label Text="Negocio" 
@@ -81,7 +82,7 @@
                                         BackgroundColor="Transparent"
                                         Margin="12,8"/>
                             </Border>
-                            
+
                             <!-- EDS -->
                             <Label Text="EDS" 
                                    FontAttributes="Bold" 
@@ -102,7 +103,7 @@
                                         BackgroundColor="Transparent"
                                         Margin="12,8"/>
                             </Border>
-                            
+
                             <!-- Islander -->
                             <Label Text="Islero" 
                                    FontAttributes="Bold" 
@@ -145,7 +146,7 @@
                                    TextColor="#2D3436"
                                    VerticalOptions="Center"/>
                         </StackLayout>
-                        
+
                         <Grid ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto" RowSpacing="16" ColumnSpacing="12">
                             <!-- Date -->
                             <StackLayout Grid.Row="0" Grid.Column="0">
@@ -224,7 +225,7 @@
                                    TextColor="#2D3436"
                                    VerticalOptions="Center"/>
                         </StackLayout>
-                        
+
                         <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*,*" RowSpacing="16" ColumnSpacing="16">
                             <!-- Sales in Money -->
                             <Border BackgroundColor="#E8F5E8" 
@@ -354,7 +355,18 @@
                 </Border>
 
                 <!-- Sales by Hoses Section -->
-                <StackLayout x:Name="AddedDispensers" IsVisible="{Binding VisibleDispenser}">
+                <StackLayout x:Name="AddedDispensers"
+                             IsVisible="{Binding VisibleDispenser}"
+                             IsEnabled="{Binding Source={x:Reference CortePage}, Path=PuedeEditar}">
+                    <StackLayout.Triggers>
+                        <!-- Ocultar después del envío -->
+                        <DataTrigger TargetType="StackLayout"
+                                     Binding="{Binding Source={x:Reference CortePage}, Path=SeccionesVisibles}"
+                                     Value="False">
+                            <Setter Property="IsVisible" Value="False" />
+                        </DataTrigger>
+                    </StackLayout.Triggers>
+
                     <Border BackgroundColor="#E8F5E8" 
                             StrokeShape="RoundRectangle 8"
                             Stroke="#4CAF50"
@@ -442,8 +454,18 @@
                     </CollectionView>
                 </StackLayout>
 
-                <!-- Collections Section -->
-                <StackLayout x:Name="TypesofAggregateCollections" IsVisible="{Binding VisibleReceipts}">
+                <!-- Collections Section (Formas de pago) -->
+                <StackLayout x:Name="TypesofAggregateCollections"
+                             IsVisible="{Binding VisibleReceipts}"
+                             IsEnabled="{Binding Source={x:Reference CortePage}, Path=PuedeEditar}">
+                    <StackLayout.Triggers>
+                        <DataTrigger TargetType="StackLayout"
+                                     Binding="{Binding Source={x:Reference CortePage}, Path=SeccionesVisibles}"
+                                     Value="False">
+                            <Setter Property="IsVisible" Value="False" />
+                        </DataTrigger>
+                    </StackLayout.Triggers>
+
                     <Border BackgroundColor="#E3F2FD" 
                             StrokeShape="RoundRectangle 8"
                             Stroke="#2196F3"
@@ -523,7 +545,7 @@
                     </CollectionView>
                 </StackLayout>
 
-                <!-- Documents Section -->
+                <!-- Documents Section (no se oculta por la tarea) -->
                 <StackLayout x:Name="AddedDocuments" IsVisible="{Binding VisibleDocuments}">
                     <Border BackgroundColor="#FFF3E0" 
                             StrokeShape="RoundRectangle 8"
@@ -586,7 +608,18 @@
                 </StackLayout>
 
                 <!-- Expenses Section -->
-                <StackLayout x:Name="AddedExpenses" IsVisible="{Binding VisibleExpenses}">
+                <StackLayout x:Name="AddedExpenses"
+                             IsVisible="{Binding VisibleExpenses}"
+                             IsEnabled="{Binding Source={x:Reference CortePage}, Path=PuedeEditar}">
+                    <StackLayout.Triggers>
+                        <!-- Ocultar después del envío -->
+                        <DataTrigger TargetType="StackLayout"
+                                     Binding="{Binding Source={x:Reference CortePage}, Path=SeccionesVisibles}"
+                                     Value="False">
+                            <Setter Property="IsVisible" Value="False" />
+                        </DataTrigger>
+                    </StackLayout.Triggers>
+
                     <Border BackgroundColor="#FFEBEE" 
                             StrokeShape="RoundRectangle 8"
                             Stroke="#F44336"
@@ -668,11 +701,11 @@
 
                 <!-- Main Action Buttons Section -->
                 <VerticalStackLayout Spacing="16" x:Name="Button" Margin="0,0,0,110">
-                    
+
                     <!-- Required Actions Card -->
                     <Border Style="{StaticResource RequiredActionsCardStyle}"
                             Margin="0,8">
-                        
+
                         <VerticalStackLayout Spacing="16">
                             <!-- Header -->
                             <StackLayout Orientation="Horizontal" Spacing="10" HorizontalOptions="Center">
@@ -683,7 +716,7 @@
                                        TextColor="#D32F2F"
                                        VerticalOptions="Center"/>
                             </StackLayout>
-                            
+
                             <!-- Required Buttons Grid -->
                             <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
                                 <Button Text="{Binding NewSale}"
@@ -693,15 +726,32 @@
                                         Command="{Binding OpenDispenserCommand}"
                                         AutomationId="AddSaleButton"
                                         IsEnabled="{Binding NewSaleEnabled}"
-                                        Grid.Column="0"/>
-                                
+                                        Grid.Column="0">
+                                    <Button.Triggers>
+                                        <!-- Bloquear si el corte ya fue enviado -->
+                                        <DataTrigger TargetType="Button"
+                                                     Binding="{Binding Source={x:Reference CortePage}, Path=PuedeEditar}"
+                                                     Value="False">
+                                            <Setter Property="IsEnabled" Value="False"/>
+                                        </DataTrigger>
+                                    </Button.Triggers>
+                                </Button>
+
                                 <Button Text="{Binding AddCollectionType}"
                                         Style="{StaticResource CompactActionButtonStyle}"
                                         BackgroundColor="#2196F3"
                                         Clicked="OpenTypeOfCollectionPopUp"
                                         AutomationId="AddCollectionTypeButton"
                                         IsEnabled="{Binding IsEdsSelected}"
-                                        Grid.Column="1"/>
+                                        Grid.Column="1">
+                                    <Button.Triggers>
+                                        <DataTrigger TargetType="Button"
+                                                     Binding="{Binding Source={x:Reference CortePage}, Path=PuedeEditar}"
+                                                     Value="False">
+                                            <Setter Property="IsEnabled" Value="False"/>
+                                        </DataTrigger>
+                                    </Button.Triggers>
+                                </Button>
                             </Grid>
                         </VerticalStackLayout>
                     </Border>
@@ -709,7 +759,7 @@
                     <!-- Primary Send Button - Destacado -->
                     <Border Style="{StaticResource PrimarySendButtonStyle}"
                             Margin="0,8">
-                        
+
                         <Button x:Name="SendData" 
                                 AutomationId="SendDataButton"
                                 Text="{Binding SendData}"
@@ -725,6 +775,12 @@
                                     <Setter Property="IsEnabled" Value="False" />
                                     <Setter Property="TextColor" Value="#BDBDBD" />
                                 </DataTrigger>
+                                <!-- Deshabilitar tras enviar -->
+                                <DataTrigger TargetType="Button"
+                                             Binding="{Binding Source={x:Reference CortePage}, Path=PuedeEditar}"
+                                             Value="False">
+                                    <Setter Property="IsEnabled" Value="False"/>
+                                </DataTrigger>
                             </Button.Triggers>
                         </Button>
                     </Border>
@@ -736,16 +792,15 @@
         <Border Style="{StaticResource EnhancedBottomNavContainerStyle}"
                 AbsoluteLayout.LayoutBounds="0,1,1,95"
                 AbsoluteLayout.LayoutFlags="PositionProportional,WidthProportional">
-            
+
             <Grid ColumnDefinitions="*,*,*,*" Padding="12,16,12,24" RowDefinitions="Auto,Auto">
-                
+                <!-- (sin cambios, el bloqueo lo hace el code-behind) -->
+
                 <!-- Upload Document Button -->
                 <Grid Grid.Column="0" x:Name="DocumentButton">
                     <Grid.GestureRecognizers>
                         <TapGestureRecognizer Tapped="OnDocumentTapped"/>
                     </Grid.GestureRecognizers>
-                    
-                    <!-- Background Circle -->
                     <Ellipse Fill="#FFF3E0" 
                              Style="{StaticResource NavCircleIndicatorStyle}"
                              x:Name="DocumentCircle">
@@ -756,8 +811,6 @@
                             </DataTrigger>
                         </Ellipse.Triggers>
                     </Ellipse>
-                    
-                    <!-- Content -->
                     <StackLayout Spacing="6" HorizontalOptions="Center" VerticalOptions="Center">
                         <Label Text="📄" FontSize="22" HorizontalOptions="Center"/>
                         <Label Text="Docs" 
@@ -774,8 +827,6 @@
                             </Label.Triggers>
                         </Label>
                     </StackLayout>
-                    
-                    <!-- Active Dot Indicator -->
                     <Ellipse Fill="#FF9800"
                              Style="{StaticResource NavDotIndicatorStyle}"
                              x:Name="DocumentDot">
@@ -792,8 +843,6 @@
                     <Grid.GestureRecognizers>
                         <TapGestureRecognizer Tapped="OnExpenseTapped"/>
                     </Grid.GestureRecognizers>
-                    
-                    <!-- Background Circle -->
                     <Ellipse Fill="#F3E5F5" 
                              Style="{StaticResource NavCircleIndicatorStyle}"
                              x:Name="ExpenseCircle">
@@ -804,8 +853,6 @@
                             </DataTrigger>
                         </Ellipse.Triggers>
                     </Ellipse>
-                    
-                    <!-- Content -->
                     <StackLayout Spacing="6" HorizontalOptions="Center" VerticalOptions="Center">
                         <Label Text="💸" FontSize="22" HorizontalOptions="Center"/>
                         <Label Text="Gastos" 
@@ -822,8 +869,6 @@
                             </Label.Triggers>
                         </Label>
                     </StackLayout>
-                    
-                    <!-- Active Dot Indicator -->
                     <Ellipse Fill="#9C27B0"
                              Style="{StaticResource NavDotIndicatorStyle}">
                         <Ellipse.Triggers>
@@ -839,8 +884,6 @@
                     <Grid.GestureRecognizers>
                         <TapGestureRecognizer Tapped="OnInfoTapped"/>
                     </Grid.GestureRecognizers>
-                    
-                    <!-- Background Circle -->
                     <Ellipse Fill="#E8EAF6" 
                              Style="{StaticResource NavCircleIndicatorStyle}">
                         <Ellipse.Triggers>
@@ -850,8 +893,6 @@
                             </DataTrigger>
                         </Ellipse.Triggers>
                     </Ellipse>
-                    
-                    <!-- Content -->
                     <StackLayout Spacing="6" HorizontalOptions="Center" VerticalOptions="Center">
                         <Label Text="💬" FontSize="22" HorizontalOptions="Center"/>
                         <Label Text="Info" 
@@ -868,8 +909,6 @@
                             </Label.Triggers>
                         </Label>
                     </StackLayout>
-                    
-                    <!-- Active Dot Indicator -->
                     <Ellipse Fill="#3F51B5"
                              Style="{StaticResource NavDotIndicatorStyle}">
                         <Ellipse.Triggers>
@@ -885,8 +924,6 @@
                     <Grid.GestureRecognizers>
                         <TapGestureRecognizer Tapped="OnHistoryTapped"/>
                     </Grid.GestureRecognizers>
-                    
-                    <!-- Background Circle -->
                     <Ellipse Fill="#E8F5E8" 
                              Style="{StaticResource NavCircleIndicatorStyle}">
                         <Ellipse.Triggers>
@@ -896,8 +933,6 @@
                             </DataTrigger>
                         </Ellipse.Triggers>
                     </Ellipse>
-                    
-                    <!-- Content -->
                     <StackLayout Spacing="6" HorizontalOptions="Center" VerticalOptions="Center">
                         <Label Text="📜" FontSize="22" HorizontalOptions="Center"/>
                         <Label Text="Lista" 
@@ -914,8 +949,6 @@
                             </Label.Triggers>
                         </Label>
                     </StackLayout>
-                    
-                    <!-- Active Dot Indicator -->
                     <Ellipse Fill="#4CAF50"
                              Style="{StaticResource NavDotIndicatorStyle}">
                         <Ellipse.Triggers>
@@ -925,7 +958,7 @@
                         </Ellipse.Triggers>
                     </Ellipse>
                 </Grid>
-                
+
                 <!-- Dynamic Sliding Indicator Background -->
                 <Border x:Name="SlidingBackground"
                         BackgroundColor="#6A1B9A"

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
@@ -17,12 +17,38 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
 {
     private CourtService _service;
     public string UserRole { get; set; } = string.Empty;
-    
+
+    // === NUEVO: control de visibilidad / edición de secciones ===
+    private bool _seccionesVisibles = true;
+    public bool SeccionesVisibles
+    {
+        get => _seccionesVisibles;
+        set
+        {
+            if (_seccionesVisibles == value) return;
+            _seccionesVisibles = value;
+            OnPropertyChanged(nameof(SeccionesVisibles));
+        }
+    }
+
+    private bool _puedeEditar = true;
+    public bool PuedeEditar
+    {
+        get => _puedeEditar;
+        set
+        {
+            if (_puedeEditar == value) return;
+            _puedeEditar = value;
+            OnPropertyChanged(nameof(PuedeEditar));
+        }
+    }
+    // ============================================================
+
     // Propiedad para el elemento activo del menú
     private string _activeNavItem = "Document";
-    public string ActiveNavItem 
-    { 
-        get => _activeNavItem; 
+    public string ActiveNavItem
+    {
+        get => _activeNavItem;
         set
         {
             _activeNavItem = value;
@@ -48,8 +74,14 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
 
         _service = CourtService.Instance;
         _service.DateStarttime = DateTime.Today;
+
+        // Mantén el BindingContext en el servicio (no romper Court.* bindings)
         BindingContext = _service;
-        
+
+        // Estado inicial: visible y editable
+        SeccionesVisibles = true;
+        PuedeEditar = true;
+
         // Configurar DatePicker después de la inicialización
         ConfigureDatePickerAsync();
 
@@ -64,18 +96,18 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
         {
             ApplyConfig(config);
         }
-        
+
         // Establecer el elemento activo inicial
         ActiveNavItem = "Document";
     }
 
     private async void ConfigureDatePickerAsync()
     {
-        await Task.Run(async () => 
+        await Task.Run(async () =>
         {
             await MainThread.InvokeOnMainThreadAsync(() =>
             {
-                try 
+                try
                 {
                     var picker = this.FindByName<DatePicker>("datePicker");
                     if (picker != null)
@@ -98,10 +130,10 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
         {
             Children =
             {
-                new Label 
-                { 
-                    Text = "🏪 Cierre De Turno", 
-                    FontSize = 24, 
+                new Label
+                {
+                    Text = "🏪 Cierre De Turno",
+                    FontSize = 24,
                     FontAttributes = FontAttributes.Bold,
                     HorizontalOptions = LayoutOptions.Center,
                     TextColor = Colors.Purple
@@ -118,22 +150,22 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
             // Manejo seguro de LoadingOverlay
             var loadingOverlay = this.FindByName<LoadingView.LoadingView>("LoadingOverlay");
             try { loadingOverlay?.ShowLoading(); } catch { }
-            
+
             // Manejo seguro de MainContent
             var mainContent = this.FindByName<ScrollView>("MainContent");
             try { if (mainContent != null) mainContent.IsVisible = false; } catch { }
-            
+
             // Manejo seguro de Business visibility
             var businessBorder = this.FindByName<Border>("Business");
-            try 
-            { 
+            try
+            {
                 if (businessBorder != null)
                     businessBorder.IsVisible = (UserRole is "Admin");
-            } 
+            }
             catch { }
 
             await _service.LoadTranslationsAsync();
-            
+
             // Animar la entrada del menú
             await AnimateBottomNavEntry();
         }
@@ -204,13 +236,20 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
                 return;
             }
 
+            // 🚫 bloqueo de navegación/edición tras enviar
+            if (!PuedeEditar)
+            {
+                await CustomAlert.ShowErrorAsync("El corte ya fue enviado. Edición bloqueada.", "Corte cerrado");
+                return;
+            }
+
             Debug.WriteLine($"Navigation tap: {navItem}");
 
             ActiveNavItem = navItem;
-            
+
             // Animar el tap
             await AnimateNavItemTap(navItem);
-            
+
             // Ejecutar la acción correspondiente
             await ExecuteNavAction(navItem);
         }
@@ -229,7 +268,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
         try
         {
             string navItem = null;
-            
+
             if (sender is TapGestureRecognizer tapGesture && tapGesture.CommandParameter is string commandParam)
             {
                 navItem = commandParam;
@@ -267,13 +306,13 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
         {
             var slidingBackground = this.FindByName<Border>("SlidingBackground");
             var bottomNavBorder = slidingBackground?.Parent?.Parent as Border;
-            
+
             if (bottomNavBorder != null)
             {
                 // Inicializar posición fuera de pantalla
                 bottomNavBorder.TranslationY = 120;
                 bottomNavBorder.Opacity = 0;
-                
+
                 // Animar entrada del menú completo
                 await Task.WhenAll(
                     bottomNavBorder.TranslateTo(0, 0, 700, Easing.SpringOut),
@@ -287,7 +326,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
                 await Task.Delay(200);
                 slidingBackground.Opacity = 0;
                 await slidingBackground.FadeTo(0.15, 300, Easing.CubicOut);
-                
+
                 // Inicializar posición del indicador
                 await AnimateToActiveItem(ActiveNavItem);
             }
@@ -328,7 +367,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
                 slidingBackground.TranslateTo(indicatorPosition, 0, 350, Easing.CubicOut),
                 slidingBackground.ScaleTo(1.1, 200, Easing.SpringOut)
             );
-            
+
             await slidingBackground.ScaleTo(1.0, 150, Easing.SpringIn);
         }
         catch (Exception ex)
@@ -346,7 +385,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
         {
             var itemGrid = this.FindByName<Grid>($"{navItem}Button");
             var itemCircle = this.FindByName<Ellipse>($"{navItem}Circle");
-            
+
             if (itemGrid == null) return;
 
             // Animación de pulso con escalado del círculo
@@ -381,12 +420,15 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
             switch (navItem)
             {
                 case "Document":
+                    if (!PuedeEditar) { await CustomAlert.ShowErrorAsync("El corte ya fue enviado.", "Corte cerrado"); return; }
                     await OpenDocumentPopUp();
                     break;
                 case "Expense":
+                    if (!PuedeEditar) { await CustomAlert.ShowErrorAsync("El corte ya fue enviado.", "Corte cerrado"); return; }
                     await OpenExpenditurePopUp();
                     break;
                 case "Info":
+                    if (!PuedeEditar) { await CustomAlert.ShowErrorAsync("El corte ya fue enviado.", "Corte cerrado"); return; }
                     await OpenAdditionalInfoPopUp();
                     break;
                 case "History":
@@ -403,6 +445,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
 
     private async Task OpenDocumentPopUp()
     {
+        if (!PuedeEditar) { await CustomAlert.ShowErrorAsync("El corte ya fue enviado.", "Corte cerrado"); return; }
         try
         {
             var popup = new AddDocuemt(_service);
@@ -417,6 +460,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
 
     private async Task OpenExpenditurePopUp()
     {
+        if (!PuedeEditar) { await CustomAlert.ShowErrorAsync("El corte ya fue enviado.", "Corte cerrado"); return; }
         try
         {
             var popup = new AddCourtExpenditure(_service);
@@ -431,6 +475,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
 
     private async Task OpenAdditionalInfoPopUp()
     {
+        if (!PuedeEditar) { await CustomAlert.ShowErrorAsync("El corte ya fue enviado.", "Corte cerrado"); return; }
         try
         {
             var popup = new AddInfo(_service);
@@ -459,6 +504,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
     // Métodos existentes adaptados
     private async void OpenDispenserPopUp(object sender, EventArgs e)
     {
+        if (!PuedeEditar) { await CustomAlert.ShowErrorAsync("El corte ya fue enviado.", "Corte cerrado"); return; }
         try
         {
             var popup = new AddDispenser(_service);
@@ -473,6 +519,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
 
     private async void OpenTypeOfCollectionPopUp(object sender, EventArgs e)
     {
+        if (!PuedeEditar) { await CustomAlert.ShowErrorAsync("El corte ya fue enviado.", "Corte cerrado"); return; }
         try
         {
             var popup = new AddCourtTypeOfCollection(_service);
@@ -554,6 +601,10 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
 
                 if (vm.LastSendWasSuccessful)
                 {
+                    // 🔴 Oculta secciones y bloquea edición tras envío
+                    OcultarSeccionesCierre();
+
+                    // (si necesitas refrescar datos generales)
                     CourtService.ResetInstanceFields();
                     _service = CourtService.Instance;
                     BindingContext = _service;
@@ -577,13 +628,29 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
         }
     }
 
+    // === NUEVO: método que oculta secciones y bloquea edición ===
+    private void OcultarSeccionesCierre()
+    {
+        // Bloquear edición
+        PuedeEditar = false;
+
+        // Ocultar usando binding (si tu XAML usa x:Reference CortePage)
+        SeccionesVisibles = false;
+
+        // Respaldo: ocultar por nombre si existen estos contenedores
+        this.FindByName<VisualElement>("SectionHoses")?.SetValue(VisualElement.IsVisibleProperty, false);     // Ventas por mangueras
+        this.FindByName<VisualElement>("SectionPayments")?.SetValue(VisualElement.IsVisibleProperty, false);  // Formas de pago
+        this.FindByName<VisualElement>("SectionExpenses")?.SetValue(VisualElement.IsVisibleProperty, false);  // Gastos
+    }
+    // ============================================================
+
     private void OnBusinessSelected(object sender, EventArgs e)
     {
         var picker = sender as Picker;
         if (picker == null) return;
-        
+
         Debug.WriteLine($"Tipo de SelectedItem: {picker.SelectedItem?.GetType()}");
-        
+
         Dispatcher.Dispatch(() =>
         {
             try
@@ -612,9 +679,9 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
     {
         var picker = sender as Picker;
         if (picker == null) return;
-        
+
         Debug.WriteLine($"Tipo de SelectedItem: {picker.SelectedItem?.GetType()}");
-        
+
         Dispatcher.Dispatch(() =>
         {
             try
@@ -642,9 +709,9 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
     {
         var picker = sender as Picker;
         if (picker == null) return;
-        
+
         Debug.WriteLine($"Tipo de SelectedItem: {picker.SelectedItem?.GetType()}");
-        
+
         Dispatcher.Dispatch(() =>
         {
             try
@@ -695,7 +762,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
                     return null;
                 }
             });
-            
+
             return result;
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary by Sourcery

Add UI controls to hide specific sections and disable editing after a shift is closed in the CourtPostView.

New Features:
- Introduce SeccionesVisibles and PuedeEditar bindable properties to manage section visibility and edit permissions.
- Prevent navigation actions and popup interactions when editing is locked by checking the PuedeEditar flag.
- Add OcultarSeccionesCierre method to hide sections and lock editing upon successful shift closure.
- Invoke the hide-and-lock logic after the close operation and reset the CourtService instance.

Enhancements:
- Initialize visibility and editing state in the constructor and retain the existing BindingContext.