### PR TITLE
feat(title): hide title in court

### DIFF
--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -91,6 +91,10 @@ namespace APP.Eds.Services.Court
                 _instance.OnPropertyChanged(nameof(SelectedBusiness));
                 _instance.OnPropertyChanged(nameof(SelectedEds));
                 _instance.OnPropertyChanged(nameof(SelectedIslander));
+                
+                // Notify visibility properties after clearing collections
+                _instance.OnPropertyChanged(nameof(ShouldShowDispensersSection));
+                _instance.OnPropertyChanged(nameof(ShouldShowPaymentMethodsSection));
             }
         }
         public static void DestroyInstance()
@@ -118,6 +122,17 @@ namespace APP.Eds.Services.Court
         public bool AreAvailableHoses => IsUserRole || HoseList != null && HoseList.Count > 0;
         public bool NewSaleEnabled => IsUserRole || (IsEdsSelected && AreAvailableHoses);
         public bool AdditionalInfoEnabled => IsUserRole || !string.IsNullOrEmpty(AdditionalInfoDescription);
+
+        // 🔥 NUEVAS PROPIEDADES PARA CONTROLAR LA VISIBILIDAD DE LAS SECCIONES
+        /// <summary>
+        /// Determina si se debe mostrar la sección "Ventas por mangueras" basándose en si hay dispensers agregados
+        /// </summary>
+        public bool ShouldShowDispensersSection => CourtDispensers != null && CourtDispensers.Any();
+
+        /// <summary>
+        /// Determina si se debe mostrar la sección "Formas de pago" basándose en si hay métodos de pago agregados
+        /// </summary>
+        public bool ShouldShowPaymentMethodsSection => CourtTypeOfCollections != null && CourtTypeOfCollections.Any();
 
         private List<HoseCourtModel> selectedHoses = new List<HoseCourtModel>();
 
@@ -2137,6 +2152,8 @@ namespace APP.Eds.Services.Court
             {
                 _courtDispensers = value;
                 OnPropertyChanged(nameof(CourtDispensers));
+                // 🔥 Notificar cambio en la visibilidad cuando cambie la colección
+                OnPropertyChanged(nameof(ShouldShowDispensersSection));
             }
         }
 
@@ -2170,6 +2187,8 @@ namespace APP.Eds.Services.Court
             {
                 _courtTypeOfCollections = value;
                 OnPropertyChanged(nameof(CourtTypeOfCollections));
+                // 🔥 Notificar cambio en la visibilidad cuando cambie la colección
+                OnPropertyChanged(nameof(ShouldShowPaymentMethodsSection));
             }
         }
 
@@ -2314,7 +2333,7 @@ namespace APP.Eds.Services.Court
             VisibleReceipts = false;
             VisibleAdditionalInfo = false;
            
- 
+
             _authToken = TokenHelper.LoadToken(Configuration.KeycloakCliendId, Configuration.KeycloakRealms);
             
 
@@ -2905,6 +2924,8 @@ GetAllEdsData()
                 CourtTypeOfCollections.Remove(collection);
                 TotalSales = GetTotalSales();
                 OnPropertyChanged(nameof(CourtTypeOfCollections));
+                // 🔥 Notificar cambio en la visibilidad después de eliminar el método de pago
+                OnPropertyChanged(nameof(ShouldShowPaymentMethodsSection));
             }
         }
 
@@ -3123,6 +3144,9 @@ GetAllEdsData()
             AddGallonsDifferenceResult(AccumulatedGallons, LastAccumulatedGallons);
 
             TotalSales = GetTotalSales();
+            
+            // 🔥 Notificar cambio en la visibilidad después de agregar el dispensador
+            OnPropertyChanged(nameof(ShouldShowDispensersSection));
         }
 
         public void AddDocumentsFromPopup(List<string> filesBase64, List<string> nombresDocumentos)
@@ -3203,6 +3227,9 @@ GetAllEdsData()
             TotalSales = GetTotalSales();
             CourtTypeOfCollectionAmount = 0;
             CourtTypeOfCollectionDescription = "";
+            
+            // 🔥 Notificar cambio en la visibilidad después de agregar el método de pago
+            OnPropertyChanged(nameof(ShouldShowPaymentMethodsSection));
         }
 
         public double GetTotalAmount()
@@ -3376,6 +3403,8 @@ GetAllEdsData()
                 OnPropertyChanged(nameof(TotalAmount));
                 OnPropertyChanged(nameof(TotalGallons));
                 OnPropertyChanged(nameof(TotalSales));
+                // 🔥 Notificar cambio en la visibilidad después de eliminar el dispensador
+                OnPropertyChanged(nameof(ShouldShowDispensersSection));
             }
         }
 

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
@@ -356,7 +356,7 @@
 
                 <!-- Sales by Hoses Section -->
                 <StackLayout x:Name="AddedDispensers"
-                             IsVisible="{Binding VisibleDispenser}"
+                             IsVisible="{Binding ShouldShowDispensersSection}"
                              IsEnabled="{Binding Source={x:Reference CortePage}, Path=PuedeEditar}">
                     <StackLayout.Triggers>
                         <!-- Ocultar después del envío -->
@@ -456,7 +456,7 @@
 
                 <!-- Collections Section (Formas de pago) -->
                 <StackLayout x:Name="TypesofAggregateCollections"
-                             IsVisible="{Binding VisibleReceipts}"
+                             IsVisible="{Binding ShouldShowPaymentMethodsSection}"
                              IsEnabled="{Binding Source={x:Reference CortePage}, Path=PuedeEditar}">
                     <StackLayout.Triggers>
                         <DataTrigger TargetType="StackLayout"

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
@@ -18,18 +18,11 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
 {
     private async Task ShowOperationalSectionsAsync()
     {
+        // 🔥 MÉTODO SIMPLIFICADO: Ya no se necesita manipular manualmente la visibilidad
+        // porque ahora está controlada por las propiedades ShouldShowDispensersSection y ShouldShowPaymentMethodsSection
         await MainThread.InvokeOnMainThreadAsync(async () =>
         {
-            // 1) Activa flags que controlan IsVisible en XAML
-            //    (XAML: AddedDispensers -> VisibleDispenser, TypesofAggregateCollections -> VisibleReceipts)
-            _service.VisibleDispenser = true;
-            _service.VisibleReceipts = true;
-
-            // 2) Fallback directo por si alguna binding no dispara
-            this.FindByName<VisualElement>("AddedDispensers")?.SetValue(VisualElement.IsVisibleProperty, true);
-            this.FindByName<VisualElement>("TypesofAggregateCollections")?.SetValue(VisualElement.IsVisibleProperty, true);
-
-            // 3) Opcional: refresca las CollectionView por si ya hay datos cargados
+            // Solo refrescar las secciones si es necesario
             await RefreshSectionsAsync(refreshDispensers: true, refreshPayments: true);
         });
     }
@@ -656,11 +649,8 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
     {
         SetEditingState(canEdit: false, showSections: false);
 
-        // Fallback directo sobre contenedores XAML (por si alguna binding no alcanza)
-        this.FindByName<VisualElement>("AddedDispensers")?.SetValue(VisualElement.IsVisibleProperty, false);
-        this.FindByName<VisualElement>("TypesofAggregateCollections")?.SetValue(VisualElement.IsVisibleProperty, false);
-        this.FindByName<VisualElement>("AddedExpenses")?.SetValue(VisualElement.IsVisibleProperty, false);
-        this.FindByName<VisualElement>("AddedDocuments")?.SetValue(VisualElement.IsVisibleProperty, false);
+        // 🔥 YA NO ES NECESARIO: La visibilidad ahora se controla automáticamente por las propiedades del servicio
+        // Las secciones se ocultarán automáticamente cuando las colecciones estén vacías después del reset
     }
 
     // --- Pickers


### PR DESCRIPTION
## Summary by Sourcery

Introduce automatic visibility logic for dispensers and payment methods sections by adding computed properties and notifying their changes, and refactor the view to remove manual visibility handling.

New Features:
- Add ShouldShowDispensersSection and ShouldShowPaymentMethodsSection properties to automatically control the visibility of the dispensers and payment methods sections based on collection contents

Enhancements:
- Trigger property change notifications for the new visibility properties on collection modifications and instance reset
- Simplify CourtPostView by removing manual UI visibility toggles and relying on bindings to the new visibility properties