### PR TITLE
fix: CreateIslander: New validation when existing name and email data

### DIFF
--- a/APP.Eds/APP.Eds/Models/Islander/IslanderResponse.cs
+++ b/APP.Eds/APP.Eds/Models/Islander/IslanderResponse.cs
@@ -15,4 +15,7 @@ public class IslanderResponse
 
     [JsonProperty("password")]
     public string Password { get; set; }
+
+    [JsonProperty("email")]
+    public string Email { get; set; }
 }

--- a/APP.Eds/APP.Eds/Services/Islander/IslanderService.cs
+++ b/APP.Eds/APP.Eds/Services/Islander/IslanderService.cs
@@ -31,6 +31,8 @@ public class EnhancedIslanderItem
 
 public class IslanderService : INotifyPropertyChanged
 {
+    public bool ActivateClearForm { get; private set; }
+    
     public event PropertyChangedEventHandler? PropertyChanged;
     
     // Collections
@@ -320,7 +322,7 @@ public class IslanderService : INotifyPropertyChanged
                 {
                     Id = islander.IdIslander, // Fixed: Use correct property name
                     Name = islander.Name,
-                    Email = GenerateEmailFromName(islander.Name), // Generate email from name
+                    Email = islander.Email, // Generate email from name
                     Firstname = ExtractFirstName(islander.Name), // Extract from full name
                     Lastname = ExtractLastName(islander.Name), // Extract from full name
                     IdEds = islander.IdEds,
@@ -539,6 +541,7 @@ public class IslanderService : INotifyPropertyChanged
     {
         try
         {
+            ActivateClearForm = false;
             if (string.IsNullOrEmpty(_authToken))
             {
                 await CustomAlert.ShowErrorAsync("No se encontró el token de autenticación", "Error de Autenticación");
@@ -551,6 +554,19 @@ public class IslanderService : INotifyPropertyChanged
                 return;
             }
 
+            bool userError = IslanderList.Any(i => i.Name.Equals(Name, StringComparison.OrdinalIgnoreCase));
+            bool emailError = IslanderList.Any(i => i.Email.Equals(Email, StringComparison.OrdinalIgnoreCase));
+
+            if (emailError)
+            {
+                await CustomAlert.ShowErrorAsync($"El correo electrónico {Email} ya está registrado. Por favor, use otro correo.", "Email Duplicado");
+                return;
+            }
+            if (userError)
+            {
+                await CustomAlert.ShowErrorAsync($"El usuario {Name} ya está registrado. Por favor, use otro nombre.", "Usuario Duplicado");
+                return;
+            }
             Islander = new IslanderModel
             {
                 Name = Name,
@@ -604,6 +620,7 @@ public class IslanderService : INotifyPropertyChanged
                     HireDate = DateTime.Now,
                     LastAccess = DateTime.Now
                 };
+                ActivateClearForm = true;
                 
                 EnhancedIslanderList.Insert(0, newIslander);
                 UpdateStatistics();
@@ -614,11 +631,13 @@ public class IslanderService : INotifyPropertyChanged
             {
                 var error = await response.Content.ReadAsStringAsync();
                 await CustomAlert.ShowErrorAsync($"No se pudo registrar el islero: {response.StatusCode}\n{error}", "Error del Servidor");
+                
             }
         }
         catch (Exception ex)
         {
             await CustomAlert.ShowErrorAsync($"Error al registrar el islero: {ex.Message}", "Error del Sistema");
+            
         }
     }
 

--- a/APP.Eds/APP.Eds/UsesCases/Islander/IslanderPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Islander/IslanderPostView.xaml
@@ -58,7 +58,7 @@
                             
                             <!-- Name -->
                             <StackLayout Grid.Row="0" Grid.Column="0">
-                                <Label Text="Nombre Completo" 
+                                <Label Text="Usuario" 
                                        FontAttributes="Bold" 
                                        TextColor="#636E72" 
                                        FontSize="14"/>
@@ -67,7 +67,7 @@
                                         Stroke="#DDD6FE" 
                                         Padding="4">
                                     <Entry Keyboard="Text"
-                                           Placeholder="Nombre completo del islero"
+                                           Placeholder="Usuario del islero"
                                            Text="{Binding Name, Mode=TwoWay}"
                                            BackgroundColor="Transparent"
                                            AutomationId="EntryName"
@@ -123,7 +123,7 @@
                                         StrokeShape="RoundRectangle 8"
                                         Stroke="#DDD6FE" 
                                         Padding="4">
-                                    <Entry Keyboard="Email"
+                                    <Entry Keyboard="Text"
                                            Placeholder="correo@ejemplo.com"
                                            Text="{Binding Email, Mode=TwoWay}"
                                            BackgroundColor="Transparent"

--- a/APP.Eds/APP.Eds/UsesCases/Islander/IslanderPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Islander/IslanderPostView.xaml.cs
@@ -124,8 +124,11 @@ public partial class IslanderPostView : ContentPage, INotifyPropertyChanged
             LoadingOverlay?.ShowLoading();
             await _islanderService.SaveIslanderDataAsync();
 
-            // Clear form after successful save
-            ClearForm();
+            if(_islanderService.ActivateClearForm)
+            {
+                ClearForm();
+            }
+
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary by Sourcery

Prevent duplicate islander registrations by validating existing names and emails, use the actual email on load, and conditionally clear the form after successful saves

Enhancements:
- Add duplicate email and name validation before saving new islanders
- Use ActivateClearForm flag to clear the form only after a successful save

Chores:
- Add ActivateClearForm property to IslanderService
- Use actual islander.Email instead of generating from name in loaded data
- Expose Email property on IslanderResponse model