### PR TITLE
feat(shopping): change message confirmation

### DIFF
--- a/APP.Eds/APP.Eds/Components/PopUp/AddShopping.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddShopping.xaml.cs
@@ -101,7 +101,7 @@ public partial class AddShopping : Popup
             }
 
             // Validate quantity
-            if (vm.Quantity <= 0)
+            if (!vm.Quantity.HasValue || vm.Quantity <= 0)
             {
                 await CustomAlert.ShowErrorAsync("Debe ingresar una cantidad válida de galones (mayor que 0)", "Cantidad Inválida");
                 return;
@@ -114,14 +114,14 @@ public partial class AddShopping : Popup
             }
 
             // Validate purchase price
-            if (vm.PurchasePrice <= 0)
+            if (!vm.PurchasePrice.HasValue || vm.PurchasePrice <= 0)
             {
                 await CustomAlert.ShowErrorAsync("Debe ingresar un precio de compra válido (mayor que 0)", "Precio de Compra Inválido");
                 return;
             }
 
             // Validate sell price
-            if (vm.SellPrice <= 0)
+            if (!vm.SellPrice.HasValue || vm.SellPrice <= 0)
             {
                 await CustomAlert.ShowErrorAsync("Debe ingresar un precio de venta válido (mayor que 0)", "Precio de Venta Inválido");
                 return;
@@ -138,23 +138,59 @@ public partial class AddShopping : Popup
                 if (!confirm) return;
             }
 
+            // ?? GUARDAR LOS VALORES ANTES DE LLAMAR AL MÉTODO PARA EVITAR QUE SE LIMPIEN
+            double quantityValue = vm.Quantity.Value;
+            double purchasePriceValue = vm.PurchasePrice.Value;
+            double sellPriceValue = vm.SellPrice.Value;
+            double totalValue = quantityValue * purchasePriceValue;
+            string productName = vm.SelectedProductCompartimentPair?.ProductName ?? "Producto seleccionado";
+            
+            // ?? GUARDAR EL STOCK ANTERIOR ANTES DE QUE SE ACTUALICE
+            double stockAnterior = vm.CurrentStock ?? 0;
+
+            // Mostrar información de debug para verificar los valores
+            System.Diagnostics.Debug.WriteLine($"Adding product - Quantity: {quantityValue}, PurchasePrice: {purchasePriceValue}, Total: {totalValue}, Stock anterior: {stockAnterior}");
+
+            // Agregar el producto al carrito
             await shoppingService.AddShoppingProductFromPopup();
 
-            // Clear form
+            // ?? CALCULAR EL STOCK ACTUALIZADO DESPUÉS DE LA COMPRA
+            double stockActualizado = stockAnterior + quantityValue;
+
+            // ? MOSTRAR EL MENSAJE DE CONFIRMACIÓN CON EL FORMATO SOLICITADO
+            await CustomAlert.ShowSuccessAsync(
+                $"Producto agregado exitosamente a la compra\n\n" +
+                $"Producto: {productName}\n" +
+                $"Stock anterior: {stockAnterior:N3} gal\n" +
+                $"Cantidad comprada: {quantityValue:N3} gal\n" +
+                $"Stock actualizado: {stockActualizado:N3} gal\n" +
+                $"Valor total: ${totalValue:N0}",
+                "Producto Agregado");
+
+            // ?? AHORA SÍ LIMPIAR EL FORMULARIO DESPUÉS DE MOSTRAR EL MENSAJE
+            vm.ResetProductForm();
+
+            // Clear form UI elements
             if (ProductCompartimentPicker != null)
                 ProductCompartimentPicker.SelectedItem = null;
             
             if (FirstEntry != null)
-                FirstEntry.IsEnabled = false;
+            {
+                FirstEntry.Text = string.Empty;
+                FirstEntry.IsEnabled = true; // Re-enable for next entry
+            }
             
             if (SecondEntry != null)
-                SecondEntry.IsEnabled = false;
+            {
+                SecondEntry.Text = string.Empty;
+                SecondEntry.IsEnabled = true; // Re-enable for next entry
+            }
             
             if (ThirdEntry != null)
-                ThirdEntry.IsEnabled = false;
-
-            // Show professional success feedback
-            await CustomAlert.ShowSuccessAsync($"Producto agregado exitosamente a la compra\n\nCantidad: {vm.Quantity:F2} galones\nValor total: ${(vm.Quantity * vm.PurchasePrice):F2}", "Producto Agregado");
+            {
+                ThirdEntry.Text = string.Empty;
+                ThirdEntry.IsEnabled = true; // Re-enable for next entry
+            }
 
             try
             {
@@ -176,7 +212,7 @@ public partial class AddShopping : Popup
             if (sender is Button button)
             {
                 button.IsEnabled = true;
-                button.Text = "?? Agregar a la Compra";
+                button.Text = "? Agregar a la Compra";
             }
         }
     }

--- a/APP.Eds/APP.Eds/Components/PopUp/CustomAlert.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/CustomAlert.xaml
@@ -35,7 +35,7 @@
                             HorizontalOptions="Center"
                             Opacity="0.9">
                         <Label x:Name="IconLabel"
-                               Text="!" 
+                               Text="i" 
                                FontSize="32"
                                FontAttributes="Bold"
                                TextColor="#8B0000"

--- a/APP.Eds/APP.Eds/Components/PopUp/CustomAlert.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/CustomAlert.xaml.cs
@@ -133,8 +133,8 @@ public partial class CustomAlert : Popup
             case AlertType.Success:
                 HeaderBorder.BackgroundColor = Color.FromArgb("#B8E6B8");
                 ConfirmButtonBorder.BackgroundColor = Color.FromArgb("#90D690");
-                IconLabel.Text = "?";
-                IconLabel.FontSize = 28;
+                IconLabel.Text = "OK";  // Usando texto simple "OK" para máxima compatibilidad
+                IconLabel.FontSize = 20;
                 IconLabel.FontAttributes = FontAttributes.Bold;
                 IconLabel.TextColor = Color.FromArgb("#006400");
                 break;

--- a/APP.Eds/APP.Eds/Models/Shopping/ProductCompartimentPairModel.cs
+++ b/APP.Eds/APP.Eds/Models/Shopping/ProductCompartimentPairModel.cs
@@ -9,5 +9,5 @@ public class ProductCompartimentPairModel
     public double Operative { get; set; }
     public double Stock { get; set; }
 
-    public string Display => $"{ProductName} - Compartimento {Number}\nCapacidad: {Operative} | Stock: {Stock}\n";
+    public string Display => $"{ProductName} - Compartimento {Number}\nCapacidad: {Operative:N0} | Stock: {Stock:N0}";
 }

--- a/APP.Eds/APP.Eds/Services/Shopping/ShoppingService.cs
+++ b/APP.Eds/APP.Eds/Services/Shopping/ShoppingService.cs
@@ -687,7 +687,12 @@ public class ShoppingService : INotifyPropertyChanged
             return;
         }
 
-       
+        // 🔧 GUARDAR LOS DATOS DEL PRODUCTO ANTES DE AGREGARLO (para evitar que se pierdan al limpiar)
+        var savedQuantity = Quantity.Value;
+        var savedPurchasePrice = PurchasePrice ?? 0;
+        var savedSellPrice = SellPrice ?? 0;
+        var savedTotalPrice = CurrentTotalAmount ?? 0;
+        var savedProductName = SelectedProductCompartimentPair?.ProductName ?? "Producto";
 
         var newProduct = new ShoppingProductNestedModel
         {
@@ -716,7 +721,9 @@ public class ShoppingService : INotifyPropertyChanged
         }
         
         UpdateAccumulatedTotals();
-        ResetProductForm();
+        
+        // 🔧 NOTA: NO LLAMAR ResetProductForm() AQUÍ - Se llamará desde el popup después de mostrar el mensaje
+        // ResetProductForm();
     }
 
     private void UpdateAccumulatedTotals()
@@ -753,6 +760,7 @@ public class ShoppingService : INotifyPropertyChanged
 
     public void ResetProductForm()
     {
+        // ✅ IMPORTANTE: Solo limpiar los campos del formulario, no afectar los datos ya agregados
         SelectedProduct = null;
         SelectedCompartiment = null;
         SelectedProductCompartimentPair = null;
@@ -760,12 +768,18 @@ public class ShoppingService : INotifyPropertyChanged
         Quantity = 0;
         SellPrice = 0;
         CurrentStock = null;
+        
+        // Notificar cambios en las propiedades para actualizar la UI
         OnPropertyChanged(nameof(PurchasePrice));
         OnPropertyChanged(nameof(Quantity));
+        OnPropertyChanged(nameof(SellPrice));
         OnPropertyChanged(nameof(CurrentTotalAmount));
         OnPropertyChanged(nameof(SelectedProduct));
         OnPropertyChanged(nameof(SelectedCompartiment));
         OnPropertyChanged(nameof(SelectedProductCompartimentPair));
+        OnPropertyChanged(nameof(CurrentStock));
+        OnPropertyChanged(nameof(IsStockAvailable));
+        OnPropertyChanged(nameof(MaxQuantityAllowed));
     }
 
     private void DeleteProduct(ShoppingProductNestedModel product)

--- a/APP.Eds/APP.Eds/UsesCases/Shopping/ShoppingPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Shopping/ShoppingPostView.xaml
@@ -375,7 +375,7 @@
                                                 <!-- Purchase Price -->
                                                 <StackLayout Grid.Row="1" Grid.Column="0">
                                                     <Label Text="Precio Compra" FontSize="11" TextColor="#666" FontAttributes="Bold" AutomationId="LabelProductPrice"/>
-                                                    <Label Text="{Binding Price, StringFormat='$ {0:N2}'}" 
+                                                    <Label Text="{Binding PurchasePrice, StringFormat='$ {0:N2}'}" 
                                                            FontSize="13" TextColor="#4CAF50" FontAttributes="Bold" AutomationId="LabelProductPriceValue"/>
                                                 </StackLayout>
 


### PR DESCRIPTION
## Summary by Sourcery

Enhance the shopping popup by adding stricter validation for nullable and non-positive inputs, preserving and logging form values, deferring form reset until after displaying a detailed confirmation, and applying UI and formatting refinements.

Bug Fixes:
- Validate null or non-positive quantities and purchase/sell prices in the shopping popup

Enhancements:
- Store and log product details before adding, defer form reset, and display an enhanced confirmation alert with product name, previous/updated stock, quantity, and total value
- Replace the CustomAlert success icon with a simple “OK” label, adjust font size, and correct the add button text
- Format ProductCompartimentPairModel display to show rounded capacity and stock values
- Refine ResetProductForm in ShoppingService to only clear input fields, remove premature reset calls, and notify property changes