### PR TITLE
feat(court): add context dinamic

### DIFF
--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
@@ -731,7 +731,7 @@
             Clicked="OpenDispenserPopUp"
             Command="{Binding OpenDispenserCommand}"
             AutomationId="AddSaleButton"
-            IsEnabled="{Binding IsBusinessSelected}"
+            IsEnabled="{Binding Source={x:Reference CortePage}, Path=CanAccessFunctionality}"
             Grid.Column="0">
                                     <Button.Triggers>
                                         <!-- Bloquear si el corte ya fue enviado -->
@@ -767,7 +767,7 @@
             Style="{StaticResource CompactActionButtonStyle}"
             Clicked="OpenTypeOfCollectionPopUp"
             AutomationId="AddCollectionTypeButton"
-            IsEnabled="{Binding IsBusinessSelected}"
+            IsEnabled="{Binding Source={x:Reference CortePage}, Path=CanAccessFunctionality}"
             Grid.Column="1">
                                     <Button.Triggers>
                                         <DataTrigger TargetType="Button"

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml.cs
@@ -565,7 +565,26 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
     /// reseteando el servicio y restableciendo las banderas de edición/visibilidad.
     /// </summary>
     /// 
-    public bool AccionesHabilitadas => PuedeEditar && IsBusinessSelected;
+    // ✅ CORREGIDO: Lógica diferente para Admin vs Usuario normal
+    public bool AccionesHabilitadas => PuedeEditar && CanAccessFunctionality;
+
+    // ✅ NUEVA PROPIEDAD: Determina si el usuario puede acceder a la funcionalidad
+    public bool CanAccessFunctionality
+    {
+        get
+        {
+            if (UserRole == "Admin")
+            {
+                // Administradores necesitan seleccionar negocio
+                return IsBusinessSelected;
+            }
+            else
+            {
+                // Usuarios normales pueden acceder siempre (se asume que ya tienen asignada su EDS)
+                return true;
+            }
+        }
+    }
 
     private async Task ResetForNewCloseAsync()
     {
@@ -589,6 +608,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
         SetEditingState(canEdit: true, showSections: true);
 
         OnPropertyChanged(nameof(AccionesHabilitadas));
+        OnPropertyChanged(nameof(CanAccessFunctionality));
 
         try { await _service.GetAllEdsData(); } catch { }
     }
@@ -620,6 +640,7 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
 
                     IsBusinessSelected = true;
                     OnPropertyChanged(nameof(AccionesHabilitadas));
+                    OnPropertyChanged(nameof(CanAccessFunctionality));
 
                     await ShowOperationalSectionsAsync();
                 }
@@ -732,6 +753,8 @@ public partial class CourtPostView : ContentPage, INotifyPropertyChanged
                 {
                     _isBusinessSelected = value;
                     OnPropertyChanged(nameof(IsBusinessSelected));
+                    OnPropertyChanged(nameof(AccionesHabilitadas));
+                    OnPropertyChanged(nameof(CanAccessFunctionality));
                 }
             }
         }


### PR DESCRIPTION
## Summary by Sourcery

Introduce dynamic, role-specific access logic in CourtPostView by adding a CanAccessFunctionality property and updating AccionesHabilitadas to reflect admin vs normal user behavior, with proper UI notifications on state changes

New Features:
- Add CanAccessFunctionality property to provide role-based access control for UI actions
- Update AccionesHabilitadas to leverage the new role-aware logic

Enhancements:
- Invoke PropertyChanged for CanAccessFunctionality alongside AccionesHabilitadas on business selection and form reset