### PR TITLE
Feature/islander

### DIFF
--- a/APP.Eds/APP.Eds/Components/PopUp/AddCourtTypeOfCollection.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddCourtTypeOfCollection.xaml
@@ -4,10 +4,17 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:mct="clr-namespace:CommunityToolkit.Maui.Views;assembly=CommunityToolkit.Maui"
+    xmlns:converters="clr-namespace:APP.Eds.Converters"
     CanBeDismissedByTappingOutsideOfPopup="False"
     x:Name="Root"
     Color="Transparent"
     AutomationId="PopupAddCourtTypeOfCollection">
+    
+    <mct:Popup.Resources>
+        <ResourceDictionary>
+            <converters:NumberToWordsConverter x:Key="NumberToWordsConverter" />
+        </ResourceDictionary>
+    </mct:Popup.Resources>
     
     <!-- Modern Minimalist Container with responsive width -->
     <Border BackgroundColor="White"
@@ -139,33 +146,72 @@
                                         </Grid>
 
                                         <!-- Amount Entry - Full Width -->
-                                        <Border BackgroundColor="White"
-                                                StrokeShape="RoundRectangle 8"
-                                                Stroke="#E0E9F7"
-                                                StrokeThickness="1"
-                                                Padding="12,8">
-                                            <Border.Triggers>
-                                                <DataTrigger TargetType="Border" Binding="{Binding IsSelected}" Value="True">
-                                                    <Setter Property="BackgroundColor" Value="#F0F7FF"/>
-                                                    <Setter Property="Stroke" Value="#90CAF9"/>
-                                                    <Setter Property="StrokeThickness" Value="2"/>
-                                                </DataTrigger>
-                                            </Border.Triggers>
-                                            <Entry Placeholder="0"
-                                                   Keyboard="Numeric"
-                                                   MaxLength="12"
-                                                   HorizontalTextAlignment="Center"
-                                                   IsEnabled="{Binding IsSelected}"
-                                                   Text="{Binding Amount, Mode=TwoWay}"
-                                                   TextChanged="Amount_TextChanged"
-                                                   Focused="Amount_Focused"
-                                                   Unfocused="Amount_Unfocused"
-                                                   TextColor="#1976D2"
-                                                   PlaceholderColor="#9E9E9E"
-                                                   BackgroundColor="Transparent"
-                                                   FontSize="13"
-                                                   FontAttributes="Bold"/>
-                                        </Border>
+                                        <StackLayout Spacing="4">
+                                            <Border BackgroundColor="White"
+                                                    StrokeShape="RoundRectangle 8"
+                                                    Stroke="#E0E9F7"
+                                                    StrokeThickness="1"
+                                                    Padding="12,8">
+                                                <Border.Triggers>
+                                                    <DataTrigger TargetType="Border" Binding="{Binding IsSelected}" Value="True">
+                                                        <Setter Property="BackgroundColor" Value="#F0F7FF"/>
+                                                        <Setter Property="Stroke" Value="#90CAF9"/>
+                                                        <Setter Property="StrokeThickness" Value="2"/>
+                                                    </DataTrigger>
+                                                </Border.Triggers>
+                                                <Entry Placeholder="0"
+                                                       Keyboard="Numeric"
+                                                       MaxLength="12"
+                                                       HorizontalTextAlignment="Center"
+                                                       IsEnabled="{Binding IsSelected}"
+                                                       Text="{Binding Amount, Mode=TwoWay}"
+                                                       TextChanged="Amount_TextChanged"
+                                                       Focused="Amount_Focused"
+                                                       Unfocused="Amount_Unfocused"
+                                                       TextColor="#1976D2"
+                                                       PlaceholderColor="#9E9E9E"
+                                                       BackgroundColor="Transparent"
+                                                       FontSize="13"
+                                                       FontAttributes="Bold"/>
+                                            </Border>
+                                            
+                                            <!-- Amount Display - Both Currency Format and Words -->
+                                            <StackLayout Orientation="Horizontal" 
+                                                         HorizontalOptions="Center"
+                                                         Spacing="8"
+                                                         IsVisible="{Binding IsSelected}">
+                                                <StackLayout.Triggers>
+                                                    <!-- Only show when there's text and item is selected -->
+                                                    <DataTrigger TargetType="StackLayout" 
+                                                                 Binding="{Binding Amount, Converter={StaticResource NumberToWordsConverter}}" 
+                                                                 Value="">
+                                                        <Setter Property="IsVisible" Value="False"/>
+                                                    </DataTrigger>
+                                                </StackLayout.Triggers>
+                                                
+                                                <!-- Currency Format -->
+                                                <Label Text="{Binding Amount, StringFormat='$ {0:N2}'}"
+                                                       FontSize="11"
+                                                       TextColor="#2196F3"
+                                                       FontAttributes="Bold"
+                                                       VerticalOptions="Center"/>
+                                                
+                                                <!-- Separator -->
+                                                <Label Text="•"
+                                                       FontSize="10"
+                                                       TextColor="#999999"
+                                                       VerticalOptions="Center"/>
+                                                
+                                                <!-- Amount in Words -->
+                                                <Label Text="{Binding Amount, Converter={StaticResource NumberToWordsConverter}}"
+                                                       FontSize="10"
+                                                       TextColor="#666666"
+                                                       FontAttributes="Italic"
+                                                       VerticalOptions="Center"
+                                                       LineBreakMode="TailTruncation"
+                                                       HorizontalOptions="FillAndExpand"/>
+                                            </StackLayout>
+                                        </StackLayout>
 
                                         <!-- Description Entry - Full Width -->
                                         <Border BackgroundColor="White"

--- a/APP.Eds/APP.Eds/Components/PopUp/AddCourtTypeOfCollection.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddCourtTypeOfCollection.xaml
@@ -115,37 +115,35 @@
                                         </DataTrigger>
                                     </Border.Triggers>
                                     
-                                    <Grid ColumnDefinitions="Auto,*,80"
-                                          RowDefinitions="Auto,Auto"
-                                          ColumnSpacing="10"
-                                          RowSpacing="12">
+                                    <StackLayout Spacing="12">
+                                        <!-- Header with checkbox and payment method name -->
+                                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+                                            <!-- Modern Checkbox -->
+                                            <CheckBox Grid.Column="0"
+                                                      IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                                      Color="#2196F3"
+                                                      VerticalOptions="Center"/>
 
-                                        <!-- Modern Checkbox -->
-                                        <CheckBox Grid.Row="0" Grid.Column="0"
-                                                  IsChecked="{Binding IsSelected, Mode=TwoWay}"
-                                                  Color="#2196F3"
-                                                  VerticalOptions="Center"/>
+                                            <!-- Payment Method Name -->
+                                            <StackLayout Grid.Column="1"
+                                                         VerticalOptions="Center"
+                                                         Spacing="2">
+                                                <Label Text="{Binding Type.Description}"
+                                                       FontSize="15"
+                                                       FontAttributes="Bold"
+                                                       TextColor="#1976D2"/>
+                                                <Label Text="Método de pago"
+                                                       FontSize="11"
+                                                       TextColor="#757575"/>
+                                            </StackLayout>
+                                        </Grid>
 
-                                        <!-- Payment Method Name -->
-                                        <StackLayout Grid.Row="0" Grid.Column="1"
-                                                     VerticalOptions="Center"
-                                                     Spacing="2">
-                                            <Label Text="{Binding Type.Description}"
-                                                   FontSize="15"
-                                                   FontAttributes="Bold"
-                                                   TextColor="#1976D2"/>
-                                            <Label Text="Método de pago"
-                                                   FontSize="11"
-                                                   TextColor="#757575"/>
-                                        </StackLayout>
-
-                                        <!-- Amount Entry -->
-                                        <Border Grid.Row="0" Grid.Column="2"
-                                                BackgroundColor="White"
+                                        <!-- Amount Entry - Full Width -->
+                                        <Border BackgroundColor="White"
                                                 StrokeShape="RoundRectangle 8"
                                                 Stroke="#E0E9F7"
                                                 StrokeThickness="1"
-                                                Padding="8,6">
+                                                Padding="12,8">
                                             <Border.Triggers>
                                                 <DataTrigger TargetType="Border" Binding="{Binding IsSelected}" Value="True">
                                                     <Setter Property="BackgroundColor" Value="#F0F7FF"/>
@@ -169,9 +167,8 @@
                                                    FontAttributes="Bold"/>
                                         </Border>
 
-                                        <!-- Description Entry -->
-                                        <Border Grid.Row="1" Grid.ColumnSpan="3"
-                                                BackgroundColor="White"
+                                        <!-- Description Entry - Full Width -->
+                                        <Border BackgroundColor="White"
                                                 StrokeShape="RoundRectangle 8"
                                                 Stroke="#E0E9F7"
                                                 StrokeThickness="1"
@@ -192,7 +189,7 @@
                                                    FontSize="13"
                                                    MaxLength="100"/>
                                         </Border>
-                                    </Grid>
+                                    </StackLayout>
                                 </Border>
                             </DataTemplate>
                         </BindableLayout.ItemTemplate>

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
@@ -98,7 +98,7 @@
                                    TextColor="#2D3436" VerticalOptions="Center"/>
                         </StackLayout>
 
-                        <Grid RowDefinitions="*,*" ColumnDefinitions="*,15,*" RowSpacing="4">
+                        <Grid RowDefinitions="*,*,*" ColumnDefinitions="*,15,*" RowSpacing="4">
                             <Label Text="Producto" VerticalOptions="Center"
                                    HorizontalOptions="End" FontSize="11" Grid.Row="0" Grid.Column="0"/>
                             <Label Text="{Binding SelectedHose.ProductEntity.Name}" 
@@ -114,6 +114,17 @@
                                        TextColor="#6A1B9A"/>
                                 <Label Text="G" VerticalOptions="Center" FontSize="9" 
                                        TextColor="#6A1B9A" FontAttributes="Bold"/>
+                            </StackLayout>
+
+                            <Label Text="Stock futuro" VerticalOptions="Center"
+                                   HorizontalOptions="End" FontSize="11" FontAttributes="Bold"
+                                   Grid.Row="2" Grid.Column="0"/>
+                            <StackLayout Orientation="Horizontal" Spacing="2" Grid.Row="2" Grid.Column="2">
+                                <Label Text="{Binding FutureStock, StringFormat='{0:N0}'}" 
+                                       VerticalOptions="Center" FontSize="11" FontAttributes="Bold"
+                                       TextColor="#4CAF50"/>
+                                <Label Text="G" VerticalOptions="Center" FontSize="9" 
+                                       TextColor="#4CAF50" FontAttributes="Bold"/>
                             </StackLayout>
                         </Grid>
                     </StackLayout>

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml
@@ -14,6 +14,7 @@
             <converters:DecimalFormatConverter x:Key="DecimalFormat" />
             <converters:CurrencyFormatConverter x:Key="CurrencyFormat" />
             <converters:IsNotNullConverter x:Key="IsNotNullConverter" />
+            <converters:NumberToWordsConverter x:Key="NumberToWordsConverter" />
         </ResourceDictionary>
     </mct:Popup.Resources>
 
@@ -211,7 +212,7 @@
                             </VerticalStackLayout>
                         </Grid>
 
-                        <Grid RowDefinitions="*,*,*" ColumnDefinitions="*,15,*" RowSpacing="5">
+                        <Grid RowDefinitions="*,*,*,*" ColumnDefinitions="*,15,*" RowSpacing="5">
                             <Label Text="Último monto acumulado" VerticalOptions="Center"
                                    HorizontalOptions="End" FontSize="11" Grid.Row="0" Grid.Column="0"/>
                             <Label Text="{Binding LastAccumulatedAmount, Converter={StaticResource CurrencyFormat}}"
@@ -238,6 +239,13 @@
                                    VerticalOptions="Center" HorizontalOptions="Start"
                                    FontAttributes="Bold" FontSize="11" TextColor="#FF9800"
                                    Grid.Row="2" Grid.Column="2"/>
+
+                            <Label Text="Monto en letras" HorizontalOptions="End" VerticalOptions="Center"
+                                   FontSize="10" Grid.Row="3" Grid.Column="0"/>
+                            <Label Text="{Binding AmountDifferenceResult, Converter={StaticResource NumberToWordsConverter}}"
+                                   VerticalOptions="Center" HorizontalOptions="Start"
+                                   FontAttributes="Italic" FontSize="9" TextColor="#666666"
+                                   Grid.Row="3" Grid.Column="2" LineBreakMode="WordWrap"/>
                         </Grid>
                     </StackLayout>
                 </Frame>

--- a/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddDispenser.xaml.cs
@@ -31,6 +31,7 @@ public partial class AddDispenser : Popup, INotifyPropertyChanged
             courtService.AccumulatedAmount = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(AmountDifferenceResult));
+            OnPropertyChanged(nameof(FutureStock));
         }
     }
 
@@ -42,6 +43,7 @@ public partial class AddDispenser : Popup, INotifyPropertyChanged
             courtService.AccumulatedGallons = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(GallonsDifferenceResult));
+            OnPropertyChanged(nameof(FutureStock));
         }
     }
 
@@ -53,6 +55,7 @@ public partial class AddDispenser : Popup, INotifyPropertyChanged
             courtService.LastAccumulatedAmount = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(AmountDifferenceResult));
+            OnPropertyChanged(nameof(FutureStock));
         }
     }
 
@@ -64,6 +67,7 @@ public partial class AddDispenser : Popup, INotifyPropertyChanged
             courtService.LastAccumulatedGallons = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(GallonsDifferenceResult));
+            OnPropertyChanged(nameof(FutureStock));
         }
     }
 
@@ -74,11 +78,27 @@ public partial class AddDispenser : Popup, INotifyPropertyChanged
         {
             courtService.SelectedHose = value;
             OnPropertyChanged();
+            OnPropertyChanged(nameof(FutureStock));
         }
     }
 
     public double AmountDifferenceResult => courtService.AmountDifferenceResult;
     public double GallonsDifferenceResult => courtService.GallonsDifferenceResult;
+
+    // Propiedad para calcular el stock futuro
+    public decimal FutureStock
+    {
+        get
+        {
+            if (SelectedHose?.ProductEntity?.Stock == null)
+                return 0;
+
+            var currentStock = SelectedHose.ProductEntity.Stock;
+            var gallonsSold = (decimal)GallonsDifferenceResult;
+            
+            return Math.Max(0, currentStock - gallonsSold);
+        }
+    }
 
     public event PropertyChangedEventHandler PropertyChanged;
 
@@ -229,6 +249,7 @@ public partial class AddDispenser : Popup, INotifyPropertyChanged
                     }
                 }
                 UpdateAccumulatedColors();
+                OnPropertyChanged(nameof(FutureStock));
             }
         });
     }
@@ -365,6 +386,8 @@ public partial class AddDispenser : Popup, INotifyPropertyChanged
                     AccumulatedGallons = LastAccumulatedGallons + (amountDifference / newSellPrice);
                     UpdateAccumulatedColors();
                 }
+                
+                OnPropertyChanged(nameof(FutureStock));
             }
             else
             {
@@ -404,6 +427,8 @@ public partial class AddDispenser : Popup, INotifyPropertyChanged
                         AccumulatedGallons = LastAccumulatedGallons + (amountDifference / newSellPrice);
                         UpdateAccumulatedColors();
                     }
+                    
+                    OnPropertyChanged(nameof(FutureStock));
                 }
                 else
                 {

--- a/APP.Eds/APP.Eds/Converters/NumberToWordsConverter.cs
+++ b/APP.Eds/APP.Eds/Converters/NumberToWordsConverter.cs
@@ -1,0 +1,142 @@
+using System.Globalization;
+
+namespace APP.Eds.Converters
+{
+    public class NumberToWordsConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null || string.IsNullOrWhiteSpace(value.ToString()))
+                return string.Empty;
+
+            if (decimal.TryParse(value.ToString(), out decimal amount))
+            {
+                if (amount == 0)
+                    return string.Empty;
+
+                return ConvertToWords(amount);
+            }
+
+            return string.Empty;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static string ConvertToWords(decimal amount)
+        {
+            try
+            {
+                if (amount == 0)
+                    return string.Empty;
+
+                long integerPart = (long)Math.Floor(amount);
+                int decimalPart = (int)((amount - integerPart) * 100);
+
+                string words = ConvertIntegerToWords(integerPart);
+                
+                if (decimalPart > 0)
+                {
+                    words += $" con {decimalPart:00}/100";
+                }
+
+                // Agregar "pesos" al final
+                words += " pesos";
+
+                // Capitalizar la primera letra
+                if (!string.IsNullOrEmpty(words))
+                {
+                    words = char.ToUpper(words[0]) + words.Substring(1);
+                }
+
+                return words;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string ConvertIntegerToWords(long number)
+        {
+            if (number == 0)
+                return "cero";
+
+            string[] units = { "", "uno", "dos", "tres", "cuatro", "cinco", "seis", "siete", "ocho", "nueve" };
+            string[] teens = { "diez", "once", "doce", "trece", "catorce", "quince", "dieciséis", "diecisiete", "dieciocho", "diecinueve" };
+            string[] tens = { "", "", "veinte", "treinta", "cuarenta", "cincuenta", "sesenta", "setenta", "ochenta", "noventa" };
+            string[] hundreds = { "", "ciento", "doscientos", "trescientos", "cuatrocientos", "quinientos", "seiscientos", "setecientos", "ochocientos", "novecientos" };
+
+            if (number < 10)
+                return units[number];
+
+            if (number < 20)
+                return teens[number - 10];
+
+            if (number < 100)
+            {
+                int ten = (int)(number / 10);
+                int unit = (int)(number % 10);
+                
+                if (ten == 2 && unit > 0)
+                    return "veinti" + units[unit];
+                
+                return tens[ten] + (unit > 0 ? " y " + units[unit] : "");
+            }
+
+            if (number == 100)
+                return "cien";
+
+            if (number < 1000)
+            {
+                int hundred = (int)(number / 100);
+                long remainder = number % 100;
+                
+                string result = hundreds[hundred];
+                if (remainder > 0)
+                    result += " " + ConvertIntegerToWords(remainder);
+                
+                return result;
+            }
+
+            if (number < 1000000)
+            {
+                long thousands = number / 1000;
+                long remainder = number % 1000;
+                
+                string result = "";
+                if (thousands == 1)
+                    result = "mil";
+                else
+                    result = ConvertIntegerToWords(thousands) + " mil";
+                
+                if (remainder > 0)
+                    result += " " + ConvertIntegerToWords(remainder);
+                
+                return result;
+            }
+
+            if (number < 1000000000)
+            {
+                long millions = number / 1000000;
+                long remainder = number % 1000000;
+                
+                string result = "";
+                if (millions == 1)
+                    result = "un millón";
+                else
+                    result = ConvertIntegerToWords(millions) + " millones";
+                
+                if (remainder > 0)
+                    result += " " + ConvertIntegerToWords(remainder);
+                
+                return result;
+            }
+
+            // Para números más grandes, simplificar
+            return "cantidad muy grande";
+        }
+    }
+}

--- a/APP.Eds/APP.Eds/Services/Court/CourtService.cs
+++ b/APP.Eds/APP.Eds/Services/Court/CourtService.cs
@@ -95,6 +95,8 @@ namespace APP.Eds.Services.Court
                 // Notify visibility properties after clearing collections
                 _instance.OnPropertyChanged(nameof(ShouldShowDispensersSection));
                 _instance.OnPropertyChanged(nameof(ShouldShowPaymentMethodsSection));
+                // 🔥 Notificar cambio en la visibilidad de la sección de Arqueo De Caja después del reset
+                _instance.OnPropertyChanged(nameof(ShouldShowCashCountSection));
             }
         }
         public static void DestroyInstance()
@@ -133,6 +135,17 @@ namespace APP.Eds.Services.Court
         /// Determina si se debe mostrar la sección "Formas de pago" basándose en si hay métodos de pago agregados
         /// </summary>
         public bool ShouldShowPaymentMethodsSection => CourtTypeOfCollections != null && CourtTypeOfCollections.Any();
+
+        /// <summary>
+        /// Determina si se debe mostrar la sección "Arqueo De Caja" basándose en si hay al menos un valor diferente de cero
+        /// </summary>
+        public bool ShouldShowCashCountSection => 
+            TotalAmount > 0 || 
+            TotalGallons > 0 || 
+            TotalExpenditure > 0 || 
+            TotalTypeOfCollection > 0 || 
+            TotalSales > 0 || 
+            Distintic > 0;
 
         private List<HoseCourtModel> selectedHoses = new List<HoseCourtModel>();
 
@@ -712,6 +725,8 @@ namespace APP.Eds.Services.Court
             {
                 _distintic = value;
                 OnPropertyChanged(nameof(Distintic)); // Fixed: Use the correct property name
+                // 🔥 Notificar cambio en la visibilidad de la sección de Arqueo De Caja cuando cambia el distintivo
+                OnPropertyChanged(nameof(ShouldShowCashCountSection));
             }
         }        
 
@@ -3277,6 +3292,8 @@ GetAllEdsData()
             OnPropertyChanged(nameof(TotalExpenditure));
             OnPropertyChanged(nameof(TotalTypeOfCollection));
             OnPropertyChanged(nameof(TotalSales));
+            // 🔥 Notificar cambio en la visibilidad de la sección de Arqueo De Caja
+            OnPropertyChanged(nameof(ShouldShowCashCountSection));
 
             return TotalAmount; // Return total sales amount
         }

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
@@ -213,7 +213,8 @@
                         BackgroundColor="White"
                         StrokeShape="RoundRectangle 12"
                         StrokeThickness="0"
-                        Padding="20">
+                        Padding="20"
+                        IsVisible="{Binding ShouldShowCashCountSection}">
                     <Border.Shadow>
                         <Shadow Brush="Black" Offset="0,2" Radius="8" Opacity="0.1"/>
                     </Border.Shadow>

--- a/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Court/CourtPostView.xaml
@@ -14,6 +14,7 @@
             <converters:DecimalFormatConverter x:Key="DecimalFormat" />
             <converters:CurrencyFormatConverter x:Key="CurrencyFormat" />
             <converters:CountToBoolConverter x:Key="CountToBoolConverter" />
+            <converters:NumberToWordsConverter x:Key="NumberToWordsConverter" />
         </ResourceDictionary>
     </ContentPage.Resources>
 
@@ -512,6 +513,9 @@
                                                 <Label Text="Monto" FontSize="12" TextColor="#666" FontAttributes="Bold"/>
                                                 <Label Text="{Binding Amount, Converter={StaticResource CurrencyFormat}}" 
                                                        FontSize="14" TextColor="#4CAF50" FontAttributes="Bold"/>
+                                                <Label Text="{Binding Amount, Converter={StaticResource NumberToWordsConverter}}" 
+                                                       FontSize="10" TextColor="#666666" FontAttributes="Italic"
+                                                       LineBreakMode="WordWrap"/>
                                             </StackLayout>
                                         </Grid>
 


### PR DESCRIPTION
## Summary by Sourcery

Implement future stock estimation in the AddDispenser popup, add conditional visibility for a new cash count section in CourtService, and introduce a NumberToWordsConverter for Spanish monetary amounts.

New Features:
- Add a FutureStock property to AddDispenser view model to calculate remaining product stock after sales.
- Add ShouldShowCashCountSection property in CourtService to control visibility of the cash count section based on aggregate totals.
- Introduce NumberToWordsConverter to render numeric values as Spanish words with “pesos” suffix.

Enhancements:
- Wire up property-changed notifications for FutureStock in the dispenser view and for ShouldShowCashCountSection in CourtService across relevant update paths.