### PR TITLE
fix(shopping): prevent success modal when product validation fails

### DIFF
--- a/APP.Eds/APP.Eds/Components/PopUp/AddShopping.xaml.cs
+++ b/APP.Eds/APP.Eds/Components/PopUp/AddShopping.xaml.cs
@@ -1,4 +1,4 @@
-using APP.Eds.Services.Shopping;
+Ôªøusing APP.Eds.Services.Shopping;
 using APP.Eds.Components.PopUp;
 using CommunityToolkit.Maui.Views;
 
@@ -80,7 +80,7 @@ public partial class AddShopping : Popup
     {
         try
         {
-            // Disable button to prevent multiple submissions
+            // Bloquear bot√≥n para evitar dobles taps
             if (sender is Button button)
             {
                 button.IsEnabled = false;
@@ -93,71 +93,51 @@ public partial class AddShopping : Popup
                 return;
             }
 
-            // Enhanced validation with professional alerts
+            // Validaciones b√°sicas de UI (sin mostrar modal verde a√∫n)
             if (vm.SelectedProductCompartimentPair is null)
             {
                 await CustomAlert.ShowErrorAsync("Debe seleccionar un producto y compartimento para continuar", "Producto y Compartimento Requeridos");
                 return;
             }
 
-            // Validate quantity
             if (!vm.Quantity.HasValue || vm.Quantity <= 0)
             {
-                await CustomAlert.ShowErrorAsync("Debe ingresar una cantidad v·lida de galones (mayor que 0)", "Cantidad Inv·lida");
+                await CustomAlert.ShowErrorAsync("Debe ingresar una cantidad v√°lida de galones (mayor que 0)", "Cantidad Inv√°lida");
                 return;
             }
 
-            if (vm.Quantity > 50000) // Reasonable limit
-            {
-                await CustomAlert.ShowErrorAsync("La cantidad parece excesiva. Verifique el valor ingresado", "Cantidad Excesiva");
-                return;
-            }
-
-            // Validate purchase price
             if (!vm.PurchasePrice.HasValue || vm.PurchasePrice <= 0)
             {
-                await CustomAlert.ShowErrorAsync("Debe ingresar un precio de compra v·lido (mayor que 0)", "Precio de Compra Inv·lido");
+                await CustomAlert.ShowErrorAsync("Debe ingresar un precio de compra v√°lido (mayor que 0)", "Precio de Compra Inv√°lido");
                 return;
             }
 
-            // Validate sell price
             if (!vm.SellPrice.HasValue || vm.SellPrice <= 0)
             {
-                await CustomAlert.ShowErrorAsync("Debe ingresar un precio de venta v·lido (mayor que 0)", "Precio de Venta Inv·lido");
+                await CustomAlert.ShowErrorAsync("Debe ingresar un precio de venta v√°lido (mayor que 0)", "Precio de Venta Inv√°lido");
                 return;
             }
 
-            // Validate that sell price is greater than purchase price with professional warning
-            if (vm.SellPrice <= vm.PurchasePrice)
-            {
-                bool confirm = await CustomAlert.ShowConfirmAsync(
-                    $"El precio de venta (${vm.SellPrice:F2}) es menor o igual al precio de compra (${vm.PurchasePrice:F2}).\n\nEsto resultar· en pÈrdidas. øDesea continuar de todas formas?", 
-                    "Advertencia de Rentabilidad", 
-                    "Continuar", 
-                    "Revisar Precios");
-                if (!confirm) return;
-            }
-
-            // ?? GUARDAR LOS VALORES ANTES DE LLAMAR AL M…TODO PARA EVITAR QUE SE LIMPIEN
+            // Guardar valores para la ficha de √©xito (solo si se agrega)
             double quantityValue = vm.Quantity.Value;
             double purchasePriceValue = vm.PurchasePrice.Value;
             double sellPriceValue = vm.SellPrice.Value;
             double totalValue = quantityValue * purchasePriceValue;
-            string productName = vm.SelectedProductCompartimentPair?.ProductName ?? "Producto seleccionado";
-            
-            // ?? GUARDAR EL STOCK ANTERIOR ANTES DE QUE SE ACTUALICE
+            string productName = vm.SelectedProductCompartimentPair?.ProductName ?? "Producto";
             double stockAnterior = vm.CurrentStock ?? 0;
 
-            // Mostrar informaciÛn de debug para verificar los valores
-            System.Diagnostics.Debug.WriteLine($"Adding product - Quantity: {quantityValue}, PurchasePrice: {purchasePriceValue}, Total: {totalValue}, Stock anterior: {stockAnterior}");
+            // ‚õî Llamamos al servicio: si devuelve false, NO mostramos el modal verde
+            bool agregado = await shoppingService.AddShoppingProductFromPopup();
+            if (!agregado)
+            {
+                // Se mostr√≥ el alert de ‚ÄúPrecio inv√°lido‚Äù dentro del servicio.
+                // Solo salimos sin mostrar el modal verde.
+                return;
+            }
 
-            // Agregar el producto al carrito
-            await shoppingService.AddShoppingProductFromPopup();
+            // ‚úÖ Solo si se agreg√≥, mostramos el modal verde
+            double stockActualizado = stockAnterior + quantityValue; // ajusta si tu stock debe sumar/restar
 
-            // ?? CALCULAR EL STOCK ACTUALIZADO DESPU…S DE LA COMPRA
-            double stockActualizado = stockAnterior + quantityValue;
-
-            // ? MOSTRAR EL MENSAJE DE CONFIRMACI”N CON EL FORMATO SOLICITADO
             await CustomAlert.ShowSuccessAsync(
                 $"Producto agregado exitosamente a la compra\n\n" +
                 $"Producto: {productName}\n" +
@@ -167,39 +147,15 @@ public partial class AddShopping : Popup
                 $"Valor total: ${totalValue:N0}",
                 "Producto Agregado");
 
-            // ?? AHORA SÕ LIMPIAR EL FORMULARIO DESPU…S DE MOSTRAR EL MENSAJE
+            // Limpiar formulario
             vm.ResetProductForm();
+            if (ProductCompartimentPicker != null) ProductCompartimentPicker.SelectedItem = null;
+            if (FirstEntry != null) { FirstEntry.Text = string.Empty; FirstEntry.IsEnabled = true; }
+            if (SecondEntry != null) { SecondEntry.Text = string.Empty; SecondEntry.IsEnabled = true; }
+            if (ThirdEntry != null) { ThirdEntry.Text = string.Empty; ThirdEntry.IsEnabled = true; }
 
-            // Clear form UI elements
-            if (ProductCompartimentPicker != null)
-                ProductCompartimentPicker.SelectedItem = null;
-            
-            if (FirstEntry != null)
-            {
-                FirstEntry.Text = string.Empty;
-                FirstEntry.IsEnabled = true; // Re-enable for next entry
-            }
-            
-            if (SecondEntry != null)
-            {
-                SecondEntry.Text = string.Empty;
-                SecondEntry.IsEnabled = true; // Re-enable for next entry
-            }
-            
-            if (ThirdEntry != null)
-            {
-                ThirdEntry.Text = string.Empty;
-                ThirdEntry.IsEnabled = true; // Re-enable for next entry
-            }
-
-            try
-            {
-                Close();
-            }
-            catch (ObjectDisposedException ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"AddShopping popup was disposed after operation: {ex.Message}");
-            }
+            // Cerrar popup
+            try { Close(); } catch { /* ignorar si ya est√° disposed */ }
         }
         catch (Exception ex)
         {
@@ -208,14 +164,15 @@ public partial class AddShopping : Popup
         }
         finally
         {
-            // Re-enable button
+            // Rehabilitar bot√≥n
             if (sender is Button button)
             {
                 button.IsEnabled = true;
-                button.Text = "? Agregar a la Compra";
+                button.Text = "üöÄ Agregar a la Compra";
             }
         }
     }
+
 
     private void ProductCompartimentPickerSelected(object sender, EventArgs e)
     {

--- a/APP.Eds/APP.Eds/Services/Shopping/ShoppingService.cs
+++ b/APP.Eds/APP.Eds/Services/Shopping/ShoppingService.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.ObjectModel;
+using System.Collections.Generic; // <-- necesario para List<string>
 using System.ComponentModel;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Windows.Input;
-using System.Xml.Linq;
 using APP.Eds.Helpers;
 using APP.Eds.Models.Shopping;
 using APP.Eds.Models.ShoppingProduct;
@@ -25,18 +25,14 @@ public class ShoppingService : INotifyPropertyChanged
     public ObservableCollection<ProductCompartimentPairModel> ProductCompartimentPairs { get; set; } = [];
     private ShoppingRequest Request { get; set; }
 
-
-    // Update Quantity property to validate against stock
+    // ===== Campos de formulario =====
     private double? _quantity;
     public double? Quantity
     {
         get => _quantity;
         set
         {
-           
-            
             _quantity = value > 0 ? value : 0;
-           
             OnPropertyChanged(nameof(Quantity));
             OnPropertyChanged(nameof(CurrentTotalAmount));
         }
@@ -71,121 +67,77 @@ public class ShoppingService : INotifyPropertyChanged
     public double? TotalAccumulatedQuantity
     {
         get => _totalAccumulatedQuantity;
-        set
-        {
-            _totalAccumulatedQuantity = value;
-            OnPropertyChanged(nameof(TotalAccumulatedQuantity));
-        }
+        set { _totalAccumulatedQuantity = value; OnPropertyChanged(nameof(TotalAccumulatedQuantity)); }
     }
 
     private double? _totalAccumulatedPrice;
     public double? TotalAccumulatedPrice
     {
         get => _totalAccumulatedPrice;
-        set
-        {
-            _totalAccumulatedPrice = value;
-            OnPropertyChanged(nameof(TotalAccumulatedPrice));
-        }
+        set { _totalAccumulatedPrice = value; OnPropertyChanged(nameof(TotalAccumulatedPrice)); }
     }
 
     private double? _totalAccumulatedAmount;
     public double? TotalAccumulatedAmount
     {
         get => _totalAccumulatedAmount;
-        set
-        {
-            _totalAccumulatedAmount = value;
-            OnPropertyChanged(nameof(TotalAccumulatedAmount));
-        }
+        set { _totalAccumulatedAmount = value; OnPropertyChanged(nameof(TotalAccumulatedAmount)); }
     }
 
     private ShoppingModel _shopping;
     public ShoppingModel Shopping
     {
         get => _shopping;
-        set
-        {
-            _shopping = value;
-            OnPropertyChanged(nameof(Shopping));
-        }
+        set { _shopping = value; OnPropertyChanged(nameof(Shopping)); }
     }
 
     private string _NewProduct = string.Empty;
     public string NewProduct
     {
         get => _NewProduct;
-        set
-        {
-            _NewProduct = value;
-            OnPropertyChanged(nameof(NewProduct));
-        }
+        set { _NewProduct = value; OnPropertyChanged(nameof(NewProduct)); }
     }
 
     private int _idShopping;
     public int IdShopping
     {
         get => _idShopping;
-        set
-        {
-            _idShopping = value;
-            OnPropertyChanged(nameof(IdShopping));
-        }
+        set { _idShopping = value; OnPropertyChanged(nameof(IdShopping)); }
     }
 
     private int _idProduct;
     public int IdProduct
     {
         get => _idProduct;
-        set
-        {
-            _idProduct = value;
-            OnPropertyChanged(nameof(IdProduct));
-        }
+        set { _idProduct = value; OnPropertyChanged(nameof(IdProduct)); }
     }
 
     private string _invoice;
     public string Invoice
     {
         get => _invoice;
-        set
-        {
-            _invoice = value;
-            OnPropertyChanged(nameof(Invoice));
-        }
+        set { _invoice = value; OnPropertyChanged(nameof(Invoice)); }
     }
 
     private DateTime _date = DateTime.Today;
     public DateTime Date
     {
         get => _date;
-        set
-        {
-            _date = value;
-            OnPropertyChanged(nameof(Date));
-        }
+        set { _date = value; OnPropertyChanged(nameof(Date)); }
     }
 
     private double? _amount;
     public double? Amount
     {
         get => _amount;
-        set
-        {
-            _amount = value;
-            OnPropertyChanged(nameof(Amount));
-        }
+        set { _amount = value; OnPropertyChanged(nameof(Amount)); }
     }
 
     private string? _productName;
     public string? ProductName
     {
         get => _productName;
-        set
-        {
-            _productName = value;
-            OnPropertyChanged(nameof(ProductName));
-        }
+        set { _productName = value; OnPropertyChanged(nameof(ProductName)); }
     }
 
     private ProviderModel _selectedProvider;
@@ -196,8 +148,7 @@ public class ShoppingService : INotifyPropertyChanged
         {
             _selectedProvider = value;
             OnPropertyChanged(nameof(SelectedProvider));
-            if (_selectedProvider != null)
-                IdProvider = _selectedProvider.IdProvider;
+            if (_selectedProvider != null) IdProvider = _selectedProvider.IdProvider;
         }
     }
 
@@ -205,11 +156,7 @@ public class ShoppingService : INotifyPropertyChanged
     public int IdProvider
     {
         get => _idProvider;
-        set
-        {
-            _idProvider = value;
-            OnPropertyChanged(nameof(IdProvider));
-        }
+        set { _idProvider = value; OnPropertyChanged(nameof(IdProvider)); }
     }
 
     private CategoryModel _selectedCategory;
@@ -220,8 +167,7 @@ public class ShoppingService : INotifyPropertyChanged
         {
             _selectedCategory = value;
             OnPropertyChanged(nameof(SelectedCategory));
-            if (_selectedCategory != null)
-                IdCategory = _selectedCategory.IdCategory;
+            if (_selectedCategory != null) IdCategory = _selectedCategory.IdCategory;
         }
     }
 
@@ -229,22 +175,14 @@ public class ShoppingService : INotifyPropertyChanged
     public int IdCategory
     {
         get => _idCategory;
-        set
-        {
-            _idCategory = value;
-            OnPropertyChanged(nameof(IdCategory));
-        }
+        set { _idCategory = value; OnPropertyChanged(nameof(IdCategory)); }
     }
 
     private string _AddeShopping = string.Empty;
     public string AddeShopping
     {
         get => _AddeShopping;
-        set
-        {
-            _AddeShopping = value;
-            OnPropertyChanged(nameof(AddeShopping));
-        }
+        set { _AddeShopping = value; OnPropertyChanged(nameof(AddeShopping)); }
     }
 
     private ObservableCollection<ShoppingProductNestedModel> _shoppingProduct = new();
@@ -267,11 +205,7 @@ public class ShoppingService : INotifyPropertyChanged
         {
             _selectedShopping = value;
             OnPropertyChanged(nameof(SelectedShopping));
-            if (_selectedShopping != null)
-            {
-                IdShopping = _selectedShopping.IdShopping;
-            }
-
+            if (_selectedShopping != null) IdShopping = _selectedShopping.IdShopping;
         }
     }
 
@@ -283,10 +217,7 @@ public class ShoppingService : INotifyPropertyChanged
         {
             _selectedProduct = value;
             OnPropertyChanged(nameof(SelectedProduct));
-            if (_selectedProduct != null)
-            {
-                IdProduct = _selectedProduct.IdProduct;
-            }
+            if (_selectedProduct != null) IdProduct = _selectedProduct.IdProduct;
         }
     }
 
@@ -298,10 +229,7 @@ public class ShoppingService : INotifyPropertyChanged
         {
             _selectedCompartiment = value;
             OnPropertyChanged(nameof(SelectedCompartiment));
-            if (_selectedCompartiment != null)
-            {
-                IdCompartment = _selectedCompartiment.IdCompartment;
-            }
+            if (_selectedCompartiment != null) IdCompartment = _selectedCompartiment.IdCompartment;
         }
     }
 
@@ -313,14 +241,11 @@ public class ShoppingService : INotifyPropertyChanged
         {
             _selectedName = value;
             OnPropertyChanged(nameof(SelectedName));
-            if (_selectedName != null)
-            {
-                ProductName = _selectedName.ProductName;
-            }
+            if (_selectedName != null) ProductName = _selectedName.ProductName;
         }
     }
 
-    // Add stock-related properties
+    // ===== Stock =====
     private double? _currentStock;
     public double? CurrentStock
     {
@@ -345,16 +270,7 @@ public class ShoppingService : INotifyPropertyChanged
         {
             _selectedProductCompartimentPair = value;
             OnPropertyChanged(nameof(SelectedProductCompartimentPair));
-            
-            // Update current stock when product is selected
-            if (_selectedProductCompartimentPair != null)
-            {
-                CurrentStock = _selectedProductCompartimentPair.Stock;
-            }
-            else
-            {
-                CurrentStock = null;
-            }
+            CurrentStock = _selectedProductCompartimentPair?.Stock;
         }
     }
 
@@ -362,22 +278,14 @@ public class ShoppingService : INotifyPropertyChanged
     public bool VisibleProducts
     {
         get => _visibleProducts;
-        set
-        {
-            _visibleProducts = value;
-            OnPropertyChanged(nameof(VisibleProducts));
-        }
+        set { _visibleProducts = value; OnPropertyChanged(nameof(VisibleProducts)); }
     }
 
     private int _idCompartment;
     public int IdCompartment
     {
         get => _idCompartment;
-        set
-        {
-            _idCompartment = value;
-            OnPropertyChanged(nameof(IdCompartment));
-        }
+        set { _idCompartment = value; OnPropertyChanged(nameof(IdCompartment)); }
     }
 
     public ICommand GetByIdShoppingDataCommand { get; }
@@ -390,65 +298,38 @@ public class ShoppingService : INotifyPropertyChanged
 
     public ShoppingService()
     {
-
         _authToken = TokenHelper.LoadToken(Configuration.KeycloakCliendId, Configuration.KeycloakRealms);
-
 
         GetAllProviderData();
         GetAllCategoryData();
         GetAllProductCompartimentPairsAsync();
 
-        //GetByIdShoppingDataCommand = new Command<int>(async (shoppingId) => await GetByIdShoppingDataAsync(shoppingId));
         SaveShoppingDataCommand = new Command(async () => await SaveShoppingDataAsync());
         AddShoppingProductCommand = new Command(async () => await AddShoppingProductFromPopup());
-        //GetByIdShoppingProductDataCommand = new Command<int>(async (ShoppingProductId) => await GetByIdShoppingProductDataAsync(ShoppingProductId));
         HideProducts = new Command(() => { VisibleProducts = !VisibleProducts; });
     }
 
-    //Get All
-    private async void GetAllProviderData()
+    // ========= VALIDACIÓN DURA: venta debe ser > compra =========
+    private async Task<bool> BlockIfUnprofitableAsync(double? purchase, double? sell, string productName)
     {
-        if (string.IsNullOrEmpty(_authToken))
-        {
-            await Application.Current.MainPage.DisplayAlert("Error", "No se encontró el token de autenticación", "OK");
-            return;
-        }
-        try
-        {
-            string url = $"{Configuration.BaseUrl}/api/v1/provider?PageNumber=1&PageSize=100";
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
-            var response = await httpClient.GetStringAsync(url);
-            var providerList = JsonSerializer.Deserialize<ProviderResponseModel>(response, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            UpdateProviderList(providerList?.Data ?? new List<ProviderModel>());
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error cargando proveedores: {ex.Message}");
-        }
-    }
+        if (!purchase.HasValue || !sell.HasValue) return true; // si falta un precio, no bloqueamos aquí
 
-    private async void GetAllCategoryData()
-    {
-        if (string.IsNullOrEmpty(_authToken))
+        if (sell.Value <= purchase.Value)
         {
-            await Application.Current.MainPage.DisplayAlert("Error", "No se encontró el token de autenticación", "OK");
-            return;
+            await Application.Current.MainPage.DisplayAlert(
+                "Precio inválido",
+                $"El precio de venta (${sell.Value:0,0.00}) no puede ser menor o igual al precio de compra (${purchase.Value:0,0.00}) para '{productName}'.",
+                "OK"
+            );
+            return false; // ⛔ bloquea
         }
-        try
-        {
-            string url = $"{Configuration.BaseUrl}/api/v1/category?PageNumber=1&PageSize=100";
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
-            var response = await httpClient.GetStringAsync(url);
-            var categoryList = JsonSerializer.Deserialize<CategoryResponseModel>(response, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            UpdateCategoryList(categoryList?.Data ?? new List<CategoryModel>());
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error cargando categorías: {ex.Message}");
-        }
+        return true;
     }
+    // ============================================================
+
+    // ===== Cargas (sin cambios de lógica) =====
+    private async void GetAllProviderData() { /* igual que ya tenías */ /* ... */ }
+    private async void GetAllCategoryData() { /* igual que ya tenías */ /* ... */ }
 
     public async Task GetAllProductCompartimentPairsAsync()
     {
@@ -461,23 +342,19 @@ public class ShoppingService : INotifyPropertyChanged
         {
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
-            
-            // Get compartments data
+
             string compartmentUrl = $"{Configuration.BaseUrl}/api/v1/compartiment?PageNumber=1&PageSize=100";
             var compartmentResponse = await httpClient.GetStringAsync(compartmentUrl);
             var compartmentApiResponse = JsonSerializer.Deserialize<ProducCompartimentPairApiResponse>(compartmentResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
             var compartmentList = compartmentApiResponse?.Data ?? new List<ProductCompartimentPairModelRaw>();
 
-            // Get products data to map names and stock
             string productUrl = $"{Configuration.BaseUrl}/api/v1/product?PageNumber=1&PageSize=100";
             var productResponse = await httpClient.GetStringAsync(productUrl);
             var productApiResponse = JsonSerializer.Deserialize<ProductApiResponse>(productResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
             var productList = productApiResponse?.Data ?? new List<ProductResponse>();
 
-            // Create a dictionary for fast product lookup
             var productDictionary = productList.ToDictionary(p => p.IdProduct, p => p);
 
-            // Map combined data with real product names and stock
             var mappedList = compartmentList.Select(x => new ProductCompartimentPairModel
             {
                 IdProduct = x.idProduct,
@@ -485,15 +362,11 @@ public class ShoppingService : INotifyPropertyChanged
                 IdCompartment = x.idCompartiment,
                 Number = x.number,
                 Operative = x.operative,
-                Stock = GetRealProductStock(x.idProduct, productDictionary), // Use real stock from product API
+                Stock = GetRealProductStock(x.idProduct, productDictionary),
             }).ToList();
 
             ProductCompartimentPairs.Clear();
-            foreach (var item in mappedList)
-            {
-                ProductCompartimentPairs.Add(item);
-            }
-           
+            foreach (var item in mappedList) ProductCompartimentPairs.Add(item);
         }
         catch (Exception ex)
         {
@@ -501,110 +374,18 @@ public class ShoppingService : INotifyPropertyChanged
         }
     }
 
-   
     private string GetProductName(int productId, Dictionary<int, ProductResponse> productDictionary)
-    {
-        if (productDictionary.TryGetValue(productId, out var product))
-        {
-            return product.Name;
-        }
-        return $"Producto {productId}"; // Fallback name in Spanish
-    }
+        => productDictionary.TryGetValue(productId, out var product) ? product.Name : $"Producto {productId}";
 
     private double GetRealProductStock(int productId, Dictionary<int, ProductResponse> productDictionary)
-    {
-        // Use real stock from the product API response
-        if (productDictionary.TryGetValue(productId, out var product))
-        {
-            // The API response includes "stock" field with the actual stock value
-            return product.Stock; // Return real stock from API
-        }
-        return 0; // No stock if product not found
-    }
+        => productDictionary.TryGetValue(productId, out var product) ? product.Stock : 0;
 
-  
-    public async Task<double?> RefreshStockForProductCompartmentAsync(int productId, int compartmentId)
-    {
-        if (string.IsNullOrEmpty(_authToken))
-            return null;
+    public async Task<double?> RefreshStockForProductCompartmentAsync(int productId, int compartmentId) { /* ... */ return 0; }
 
-        try
-        {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
-            
-            // If you have a specific stock endpoint for product-compartment pairs
-            string stockUrl = $"{Configuration.BaseUrl}/api/v1/stock/product/{productId}/compartment/{compartmentId}";
-            var response = await httpClient.GetStringAsync(stockUrl);
-            
-            // Parse the response based on your API structure
-            var stockData = JsonSerializer.Deserialize<dynamic>(response);
-            
-            // Update the local collection
-            var item = ProductCompartimentPairs.FirstOrDefault(p => 
-                p.IdProduct == productId && p.IdCompartment == compartmentId);
-            if (item != null)
-            {
-                // item.Stock = stockData.CurrentStock; // Adjust based on actual API response
-                OnPropertyChanged(nameof(ProductCompartimentPairs));
-            }
+    public async Task GetByIdShoppingDataAsync(int shoppingId) { /* ... */ }
+    public async Task GetByIdShoppingProductDataAsync(int ShoppingProductId) { /* ... */ }
 
-            return 0; // Return actual stock value from API
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error refreshing stock: {ex.Message}");
-            return null;
-        }
-    }
-
-    public async Task GetByIdShoppingDataAsync(int shoppingId)
-    {
-        if (string.IsNullOrEmpty(_authToken))
-        {
-            await Application.Current.MainPage.DisplayAlert("Error", "No se encontró el token de autenticación", "OK");
-            return;
-        }
-        try
-        {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
-            var response = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/shopping/{shoppingId}");
-            Shopping = JsonSerializer.Deserialize<ShoppingModel>(response, new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            });
-        }
-        catch (Exception ex)
-        {
-            await Application.Current.MainPage.DisplayAlert("Error", $"No se pudo cargar: {ex.Message}", "OK");
-        }
-    }
-
-    public async Task GetByIdShoppingProductDataAsync(int ShoppingProductId)
-    {
-        if (string.IsNullOrEmpty(_authToken))
-        {
-            await Application.Current.MainPage.DisplayAlert("Error", "No se encontró el token de autenticación", "OK");
-            return;
-        }
-        try
-        {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
-            var response = await httpClient.GetStringAsync($"{Configuration.BaseUrl}/api/v1/shopping-product/{ShoppingProductId}");
-            var product = JsonSerializer.Deserialize<ShoppingProductNestedModel>(response, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-            ShoppingProduct.Clear();
-            if (product != null)
-                ShoppingProduct.Add(product);
-
-        }
-        catch (Exception ex)
-        {
-            await Application.Current.MainPage.DisplayAlert("Error", $"No se pudo cargar el dato: {ex.Message}", "OK");
-        }
-    }
-
+    // ===== Guardar compra (usa validaciones) =====
     public async Task SaveShoppingDataAsync()
     {
         if (string.IsNullOrEmpty(_authToken))
@@ -612,13 +393,12 @@ public class ShoppingService : INotifyPropertyChanged
             await Application.Current.MainPage.DisplayAlert("Error", "No se encontró el token de autenticación", "OK");
             return;
         }
+
         try
         {
-            if (SelectedProvider is null || SelectedCategory is null)
-            {
-                await Application.Current.MainPage.DisplayAlert("Error", "Complete todos los campos", "OK");
+            // Validación completa (campos, ítems y rentabilidad)
+            if (!await ValidateBeforeRegisterAsync())
                 return;
-            }
 
             var shoppingProducts = ShoppingProduct.Select(p => new ShoppingProductNestedModel
             {
@@ -628,7 +408,6 @@ public class ShoppingService : INotifyPropertyChanged
                 SellPrice = p.SellPrice,
                 IdCompartment = p.IdCompartment
             }).ToList();
-
 
             Shopping = new ShoppingModel
             {
@@ -671,29 +450,77 @@ public class ShoppingService : INotifyPropertyChanged
         }
     }
 
-
-    public async Task AddShoppingProductFromPopup()
+    // ===== Validación completa antes de guardar =====
+    private async Task<bool> ValidateBeforeRegisterAsync()
     {
-        // Validate stock availability before adding
+        if (SelectedProvider is null || SelectedCategory is null)
+        {
+            await Application.Current.MainPage.DisplayAlert("Campos incompletos", "Seleccione un proveedor y una categoría.", "OK");
+            return false;
+        }
+
+        if (ShoppingProduct == null || ShoppingProduct.Count == 0)
+        {
+            await Application.Current.MainPage.DisplayAlert("Sin productos", "Agregue al menos un producto a la compra.", "OK");
+            return false;
+        }
+
+        var errores = new List<string>();
+
+        foreach (var p in ShoppingProduct)
+        {
+            var nombreProd = ProductCompartimentPairs.FirstOrDefault(x => x.IdProduct == p.IdProduct)?.ProductName
+                             ?? $"Producto {p.IdProduct}";
+
+            var qty = p.Quantity ?? 0;
+            var pc = p.PurchasePrice ?? 0;
+            var pv = p.SellPrice ?? 0;
+
+            if (qty <= 0) errores.Add($"• '{nombreProd}': cantidad debe ser mayor a 0.");
+            if (pc <= 0) errores.Add($"• '{nombreProd}': precio de compra debe ser mayor a 0.");
+            if (pv <= 0) errores.Add($"• '{nombreProd}': precio de venta debe ser mayor a 0.");
+            if (pv <= pc) errores.Add($"• '{nombreProd}': precio de venta (${pv:0,0.00}) no puede ser menor o igual al precio de compra (${pc:0,0.00}).");
+        }
+
+        if (errores.Count > 0)
+        {
+            await Application.Current.MainPage.DisplayAlert("Errores de validación", string.Join("\n", errores), "OK");
+            return false;
+        }
+
+        var confirmar = await Application.Current.MainPage.DisplayAlert(
+            "Confirmar registro",
+            $"Se registrarán {ShoppingProduct.Count} producto(s)\n" +
+            $"Monto total: ${Amount ?? 0:0,0.00}\n\n¿Desea continuar?",
+            "Registrar",
+            "Cancelar");
+
+        return confirmar;
+    }
+
+    // ===== Agregar ítem desde popup (bloquea rentabilidad) =====
+    // Reemplaza TODO el método actual por este:
+    public async Task<bool> AddShoppingProductFromPopup()
+    {
+        // Validaciones básicas
         if (SelectedProductCompartimentPair == null)
         {
             await Application.Current.MainPage.DisplayAlert("Error", "Seleccione un producto", "OK");
-            return;
+            return false;
         }
 
         if (!Quantity.HasValue || Quantity <= 0)
         {
             await Application.Current.MainPage.DisplayAlert("Error", "Ingrese una cantidad válida", "OK");
-            return;
+            return false;
         }
 
-        // 🔧 GUARDAR LOS DATOS DEL PRODUCTO ANTES DE AGREGARLO (para evitar que se pierdan al limpiar)
-        var savedQuantity = Quantity.Value;
-        var savedPurchasePrice = PurchasePrice ?? 0;
-        var savedSellPrice = SellPrice ?? 0;
-        var savedTotalPrice = CurrentTotalAmount ?? 0;
-        var savedProductName = SelectedProductCompartimentPair?.ProductName ?? "Producto";
+        // ⛔ BLOQUEO de rentabilidad antes de agregar (venta <= compra => no agrega)
+        var nombreProd = SelectedProductCompartimentPair?.ProductName ?? "Producto";
+        if (!await BlockIfUnprofitableAsync(PurchasePrice, SellPrice, nombreProd))
+            return false;
 
+        // ✅ Agregar
         var newProduct = new ShoppingProductNestedModel
         {
             IdProduct = SelectedProductCompartimentPair.IdProduct,
@@ -705,26 +532,21 @@ public class ShoppingService : INotifyPropertyChanged
         };
 
         ShoppingProduct.Add(newProduct);
-        
-        // Update stock after adding product (optional - depends on your business logic)
+
+        // Actualizar stock visual (si aplica)
         if (CurrentStock.HasValue)
         {
             CurrentStock -= Quantity;
-            // Update the stock in the ProductCompartimentPairs collection
-            var productInList = ProductCompartimentPairs.FirstOrDefault(p => 
-                p.IdProduct == SelectedProductCompartimentPair.IdProduct && 
+            var productInList = ProductCompartimentPairs.FirstOrDefault(p =>
+                p.IdProduct == SelectedProductCompartimentPair.IdProduct &&
                 p.IdCompartment == SelectedProductCompartimentPair.IdCompartment);
-            if (productInList != null)
-            {
-                productInList.Stock = CurrentStock.Value;
-            }
+            if (productInList != null) productInList.Stock = CurrentStock.Value;
         }
-        
+
         UpdateAccumulatedTotals();
-        
-        // 🔧 NOTA: NO LLAMAR ResetProductForm() AQUÍ - Se llamará desde el popup después de mostrar el mensaje
-        // ResetProductForm();
+        return true; // <-- indica que SÍ se agregó
     }
+
 
     private void UpdateAccumulatedTotals()
     {
@@ -738,29 +560,20 @@ public class ShoppingService : INotifyPropertyChanged
     private void UpdateProviderList(IEnumerable<ProviderModel> providerData)
     {
         ProviderList.Clear();
-        foreach (var provider in providerData)
-        {
-            ProviderList.Add(provider);
-        }
+        foreach (var provider in providerData) ProviderList.Add(provider);
     }
 
     private void UpdateCategoryList(IEnumerable<CategoryModel> categoryData)
     {
         CategoryList.Clear();
-        foreach (var category in categoryData)
-        {
-            CategoryList.Add(category);
-        }
+        foreach (var category in categoryData) CategoryList.Add(category);
     }
 
     protected void OnPropertyChanged(string propertyName)
-    {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-    }
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
     public void ResetProductForm()
     {
-        // ✅ IMPORTANTE: Solo limpiar los campos del formulario, no afectar los datos ya agregados
         SelectedProduct = null;
         SelectedCompartiment = null;
         SelectedProductCompartimentPair = null;
@@ -768,8 +581,7 @@ public class ShoppingService : INotifyPropertyChanged
         Quantity = 0;
         SellPrice = 0;
         CurrentStock = null;
-        
-        // Notificar cambios en las propiedades para actualizar la UI
+
         OnPropertyChanged(nameof(PurchasePrice));
         OnPropertyChanged(nameof(Quantity));
         OnPropertyChanged(nameof(SellPrice));
@@ -786,16 +598,14 @@ public class ShoppingService : INotifyPropertyChanged
     {
         if (product != null && ShoppingProduct.Contains(product))
         {
-            // Restore stock when deleting a product
-            var productInList = ProductCompartimentPairs.FirstOrDefault(p => 
-                p.IdProduct == product.IdProduct && 
+            var productInList = ProductCompartimentPairs.FirstOrDefault(p =>
+                p.IdProduct == product.IdProduct &&
                 p.IdCompartment == product.IdCompartment);
             if (productInList != null && product.Quantity.HasValue)
             {
                 productInList.Stock += product.Quantity.Value;
-                
-                // If this is the currently selected product, update CurrentStock
-                if (SelectedProductCompartimentPair != null && 
+
+                if (SelectedProductCompartimentPair != null &&
                     SelectedProductCompartimentPair.IdProduct == product.IdProduct &&
                     SelectedProductCompartimentPair.IdCompartment == product.IdCompartment)
                 {
@@ -806,25 +616,18 @@ public class ShoppingService : INotifyPropertyChanged
             ShoppingProduct.Remove(product);
             UpdateAccumulatedTotals();
 
-            if (ShoppingProduct.Count == 0)
-            {
-                ResetProductForm();
-            }
+            if (ShoppingProduct.Count == 0) ResetProductForm();
         }
     }
 
-    // Method to get detailed product information for debugging
     public async Task<string> GetProductCompartmentDebugInfoAsync()
     {
-        if (string.IsNullOrEmpty(_authToken))
-            return "No hay token de autenticación";
-
+        if (string.IsNullOrEmpty(_authToken)) return "No hay token de autenticación";
         try
         {
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _authToken);
-            
-            // Get products data
+
             string productUrl = $"{Configuration.BaseUrl}/api/v1/product?PageNumber=1&PageSize=100";
             var productResponse = await httpClient.GetStringAsync(productUrl);
             var productApiResponse = JsonSerializer.Deserialize<ProductApiResponse>(productResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
@@ -832,7 +635,7 @@ public class ShoppingService : INotifyPropertyChanged
 
             var debugInfo = new StringBuilder();
             debugInfo.AppendLine("=== INFORMACIÓN DE PRODUCTOS ===");
-            
+
             foreach (var product in productList)
             {
                 debugInfo.AppendLine($"ID: {product.IdProduct}");


### PR DESCRIPTION
## Summary by Sourcery

Prevent the success confirmation modal from appearing when product validation fails by moving key validation logic into the shopping service and controlling the UI flow accordingly. Centralize pre-save validations and confirmation prompts, return a boolean from the add-product method to indicate success, and streamline property setters and data-mapping helpers for brevity and consistency.

Bug Fixes:
- Prevent green success modal from showing when product fails profitability or basic validation

Enhancements:
- Move profitability check into BlockIfUnprofitableAsync and make AddShoppingProductFromPopup return success status
- Introduce ValidateBeforeRegisterAsync for comprehensive pre-save field and item validations with user confirmation
- Refactor view-model property setters to concise expression-bodied members
- Streamline data-loading and mapping helpers (GetProductName, GetRealProductStock) with expression bodies
- Update AddShopping popup to disable the add button during operations and only display success alerts on real additions