### PR TITLE
feat(SDK): Android SDK update

### DIFF
--- a/APP.Eds/APP.Eds/APP.Eds.csproj
+++ b/APP.Eds/APP.Eds/APP.Eds.csproj
@@ -43,14 +43,70 @@
 	  <PublishReadyToRun>False</PublishReadyToRun>
 	</PropertyGroup>
 
+	<!-- ANDROID: Configuración para API 35 -->
+	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+		<AndroidMinSdkVersion>21</AndroidMinSdkVersion>
+		<AndroidTargetSdkVersion>35</AndroidTargetSdkVersion>
+		<AndroidCompileSdkVersion>35</AndroidCompileSdkVersion>
+		<TargetFrameworkVersion>v14.0</TargetFrameworkVersion>
+		<!-- Evita que el build "baje" al último conocido por VS -->
+		<UseLatestAndroidSdk>false</UseLatestAndroidSdk>
+		<!-- Asegurar que use la versión específica -->
+		<AndroidSdkDirectory Condition="'$(AndroidSdkDirectory)' == ''">$(ANDROID_HOME)</AndroidSdkDirectory>
+	</PropertyGroup>
+
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-android|AnyCPU'">
 	  <AndroidUseAapt2>True</AndroidUseAapt2>
 	  <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
 	  <AndroidPackageFormat>apk</AndroidPackageFormat>
+	  <ApplicationVersion>5</ApplicationVersion>
+	  <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
+	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-android|AnyCPU'">
 	  <AndroidPackageFormat>apk</AndroidPackageFormat>
+	  <AndroidUseAapt2>True</AndroidUseAapt2>
+	  <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
+	  <ApplicationVersion>5</ApplicationVersion>
+	  <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
+	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
+	  <ApplicationVersion>5</ApplicationVersion>
+	  <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
+	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-maccatalyst|AnyCPU'">
+	  <ApplicationVersion>5</ApplicationVersion>
+	  <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
+	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-windows10.0.19041.0|AnyCPU'">
+	  <ApplicationVersion>5</ApplicationVersion>
+	  <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
+	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios|AnyCPU'">
+	  <ApplicationVersion>5</ApplicationVersion>
+	  <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
+	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-maccatalyst|AnyCPU'">
+	  <ApplicationVersion>5</ApplicationVersion>
+	  <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
+	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-windows10.0.19041.0|AnyCPU'">
+	  <ApplicationVersion>5</ApplicationVersion>
+	  <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
+	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/APP.Eds/APP.Eds/Platforms/Android/AndroidManifest.xml
+++ b/APP.Eds/APP.Eds/Platforms/Android/AndroidManifest.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+	<uses-sdk android:targetSdkVersion="35" />
 	<application android:allowBackup="true" android:icon="@mipmap/logoicono" android:roundIcon="@mipmap/logoicono" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />

--- a/APP.Eds/APP.Eds/UsesCases/Hose/HosePostView.xaml
+++ b/APP.Eds/APP.Eds/UsesCases/Hose/HosePostView.xaml
@@ -284,7 +284,7 @@
                                         BackgroundColor="Transparent"
                                         Clicked="OnCompartimentButtonClicked"
                                         AutomationId="ButtonCompartiment"
-                                        FontSize="16"
+                                        FontSize="14"
                                         FontAttributes="Bold"
                                         HeightRequest="50"
                                         CornerRadius="16"


### PR DESCRIPTION
## Summary by Sourcery

Update the Android project to target SDK level 35 and synchronize the project file to use the corresponding Android SDK packages

Enhancements:
- Bump Android targetSdkVersion to 35 in AndroidManifest.xml
- Update Android SDK references in APP.Eds.csproj