### PR TITLE
Upgrade to net9

### DIFF
--- a/.github/upgrades/dotnet-upgrade-plan.md
+++ b/.github/upgrades/dotnet-upgrade-plan.md
@@ -1,0 +1,64 @@
+# .NET 9 Upgrade Plan
+
+## Execution Steps
+
+Execute steps below sequentially one by one in the order they are listed.
+
+1. Validate that a .NET 9 SDK required for this upgrade is installed on the machine and if not, help to get it installed.
+2. Ensure that the SDK version specified in global.json files is compatible with the .NET 9 upgrade.
+3. Upgrade Helpers\Helpers.csproj
+4. Upgrade Mobile_views\Mobile_views.csproj
+5. Upgrade Mobile_tests\Mobile_tests.csproj
+6. Upgrade APP.Eds\Poliedro.csproj
+
+## Settings
+
+This section contains settings and data used by execution steps.
+
+### Aggregate NuGet packages modifications across all projects
+
+NuGet packages used across all selected projects or their dependencies that need version update in projects that reference them.
+
+| Package Name                         | Current Version | New Version | Description                                   |
+|:-------------------------------------|:---------------:|:-----------:|:----------------------------------------------|
+| Microsoft.Extensions.Configuration.Json | 8.0.1         | 9.0.10      | Recommended for .NET 9                        |
+| Microsoft.Extensions.Logging.Debug  | 8.0.1           | 9.0.10      | Recommended for .NET 9                        |
+| Microsoft.NET.ILLink.Tasks          | 8.0.15          | 9.0.10      | Recommended for .NET 9                        |
+| Newtonsoft.Json                     | 13.0.3          | 13.0.4      | Recommended for .NET 9                        |
+
+### Project upgrade details
+This section contains details about each project upgrade and modifications that need to be done in the project.
+
+#### Helpers\Helpers.csproj modifications
+
+Project properties changes:
+  - Target framework should be changed from `net8.0` to `net9.0`
+
+NuGet packages changes:
+  - Microsoft.Extensions.Configuration.Json should be updated from `8.0.1` to `9.0.10` (*recommended for .NET 9*)
+  - Microsoft.NET.ILLink.Tasks should be updated from `8.0.15` to `9.0.10` (*recommended for .NET 9*)
+
+#### Mobile_views\Mobile_views.csproj modifications
+
+Project properties changes:
+  - Target framework should be changed from `net8.0` to `net9.0`
+
+NuGet packages changes:
+  - Microsoft.NET.ILLink.Tasks should be updated from `8.0.15` to `9.0.10` (*recommended for .NET 9*)
+
+#### Mobile_tests\Mobile_tests.csproj modifications
+
+Project properties changes:
+  - Target framework should be changed from `net8.0` to `net9.0`
+
+NuGet packages changes:
+  - Microsoft.NET.ILLink.Tasks should be updated from `8.0.15` to `9.0.10` (*recommended for .NET 9*)
+
+#### APP.Eds\Poliedro.csproj modifications
+
+Project properties changes:
+  - Target frameworks should be changed from `net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041.0` to `net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041.0`
+
+NuGet packages changes:
+  - Microsoft.Extensions.Logging.Debug should be updated from `8.0.1` to `9.0.10` (*recommended for .NET 9*)
+  - Newtonsoft.Json should be updated from `13.0.3` to `13.0.4` (*recommended for .NET 9*)

--- a/APP.Eds/APP.Eds/Poliedro.csproj
+++ b/APP.Eds/APP.Eds/Poliedro.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
     <!-- Note for MacCatalyst:
 		The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
 		When specifying both architectures, use the plural <RuntimeIdentifiers> instead of the singular <RuntimeIdentifier>.
@@ -21,8 +21,9 @@
     <!-- App Identifier -->
     <ApplicationId>com.companyname.app.eds</ApplicationId>
     <!-- Versions -->
-    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+    <ApplicationVersion>7</ApplicationVersion>
+    <PackageVersion>1.0.1</PackageVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
@@ -30,7 +31,7 @@
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0-windows10.0.19041.0'">
+  <PropertyGroup Condition="'$(TargetFramework)'=='net9.0-windows10.0.19041.0'">
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishReadyToRun>False</PublishReadyToRun>
   </PropertyGroup>
@@ -45,53 +46,38 @@
     <!-- Asegurar que use la versión específica -->
     <AndroidSdkDirectory Condition="'$(AndroidSdkDirectory)' == ''">$(ANDROID_HOME)</AndroidSdkDirectory>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-android|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-android|AnyCPU'">
     <AndroidUseAapt2>True</AndroidUseAapt2>
     <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
     <AndroidPackageFormat>aab</AndroidPackageFormat>
-    <ApplicationVersion>7</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
     <ApplicationId>com.companyname.app.EDS</ApplicationId>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-android|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-android|AnyCPU'">
     <AndroidPackageFormat>aab</AndroidPackageFormat>
     <AndroidUseAapt2>True</AndroidUseAapt2>
     <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
-    <ApplicationVersion>7</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
     <ApplicationId>com.companyname.app.EDS</ApplicationId>
     <AndroidLinkTool>r8</AndroidLinkTool>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
-    <ApplicationVersion>7</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-ios|AnyCPU'">
     <ApplicationId>com.companyname.app.EDS</ApplicationId>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-maccatalyst|AnyCPU'">
-    <ApplicationVersion>7</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-maccatalyst|AnyCPU'">
     <ApplicationId>com.companyname.app.EDS</ApplicationId>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-windows10.0.19041.0|AnyCPU'">
-    <ApplicationVersion>7</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-windows10.0.19041.0|AnyCPU'">
     <ApplicationId>com.companyname.app.EDS</ApplicationId>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios|AnyCPU'">
-    <ApplicationVersion>7</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-ios|AnyCPU'">
     <ApplicationId>com.companyname.app.EDS</ApplicationId>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-maccatalyst|AnyCPU'">
-    <ApplicationVersion>7</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-maccatalyst|AnyCPU'">
     <ApplicationId>com.companyname.app.EDS</ApplicationId>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-windows10.0.19041.0|AnyCPU'">
-    <ApplicationVersion>7</ApplicationVersion>
-    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-windows10.0.19041.0|AnyCPU'">
     <ApplicationId>com.companyname.app.EDS</ApplicationId>
   </PropertyGroup>
+
   <ItemGroup>
     <!-- App Icon -->
     <MauiIcon Include="Resources\AppIcon\logoicono.svg" />
@@ -141,8 +127,8 @@
     <PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.10" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Components\PopUp\Category.xaml.cs">

--- a/APP.Eds/APP.Eds/Poliedro.csproj
+++ b/APP.Eds/APP.Eds/Poliedro.csproj
@@ -1,355 +1,321 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
-		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
-
-		<!-- Note for MacCatalyst:
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
+    <!-- Note for MacCatalyst:
 		The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
 		When specifying both architectures, use the plural <RuntimeIdentifiers> instead of the singular <RuntimeIdentifier>.
 		The Mac App Store will NOT accept apps with ONLY maccatalyst-arm64 indicated;
 		either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
-		<!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
-
-		<OutputType>Exe</OutputType>
-		<RootNamespace>APP.Eds</RootNamespace>
-		<UseMaui>true</UseMaui>
-		<SingleProject>true</SingleProject>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-
-		<!-- Display name -->
-		<ApplicationTitle>Poliedro</ApplicationTitle>
-
-		<!-- App Identifier -->
-		<ApplicationId>com.companyname.app.eds</ApplicationId>
-
-		<!-- Versions -->
-		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-		<ApplicationVersion>1</ApplicationVersion>
-
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(TargetFramework)'=='net8.0-windows10.0.19041.0'">
-  	  <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-	  <PublishReadyToRun>False</PublishReadyToRun>
-	</PropertyGroup>
-
-	<!-- ANDROID: Configuración para API 35 -->
-	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-		<AndroidMinSdkVersion>21</AndroidMinSdkVersion>
-		<AndroidTargetSdkVersion>35</AndroidTargetSdkVersion>
-		<AndroidCompileSdkVersion>35</AndroidCompileSdkVersion>
-		<TargetFrameworkVersion>v14.0</TargetFrameworkVersion>
-		<!-- Evita que el build "baje" al último conocido por VS -->
-		<UseLatestAndroidSdk>false</UseLatestAndroidSdk>
-		<!-- Asegurar que use la versión específica -->
-		<AndroidSdkDirectory Condition="'$(AndroidSdkDirectory)' == ''">$(ANDROID_HOME)</AndroidSdkDirectory>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-android|AnyCPU'">
-	  <AndroidUseAapt2>True</AndroidUseAapt2>
-	  <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
-	  <AndroidPackageFormat>aab</AndroidPackageFormat>
-	  <ApplicationVersion>7</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
-	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-android|AnyCPU'">
-	  <AndroidPackageFormat>aab</AndroidPackageFormat>
-	  <AndroidUseAapt2>True</AndroidUseAapt2>
-	  <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
-	  <ApplicationVersion>7</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
-	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
-	  <AndroidLinkTool>r8</AndroidLinkTool>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
-	  <ApplicationVersion>7</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
-	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-maccatalyst|AnyCPU'">
-	  <ApplicationVersion>7</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
-	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-windows10.0.19041.0|AnyCPU'">
-	  <ApplicationVersion>7</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
-	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios|AnyCPU'">
-	  <ApplicationVersion>7</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
-	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-maccatalyst|AnyCPU'">
-	  <ApplicationVersion>7</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
-	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-windows10.0.19041.0|AnyCPU'">
-	  <ApplicationVersion>7</ApplicationVersion>
-	  <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
-	  <ApplicationId>com.companyname.app.EDS</ApplicationId>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<!-- App Icon -->
-		
-		<MauiIcon Include="Resources\AppIcon\logoicono.svg" />
-		
-
-		<!-- Splash Screen -->
-		<MauiSplashScreen Include="Resources\Splash\logosplash.svg" Color="#FFFFFF" BaseSize="512,512" />
-
-
-
-		<!-- Images -->
-		<MauiImage Include="Resources\Images\*" />
-		<MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185" />
-
-		<!-- Custom Fonts -->
-		<MauiFont Include="Resources\Fonts\*" />
-
-		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
-		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <AndroidResource Remove="NewFolder\**" />
-	  <AndroidResource Remove="Services\ClearFields\**" />
-	  <AndroidResource Remove="TestAutomation\**" />
-	  <Compile Remove="NewFolder\**" />
-	  <Compile Remove="Services\ClearFields\**" />
-	  <Compile Remove="TestAutomation\**" />
-	  <EmbeddedResource Remove="NewFolder\**" />
-	  <EmbeddedResource Remove="Services\ClearFields\**" />
-	  <EmbeddedResource Remove="TestAutomation\**" />
-	  <MauiCss Remove="NewFolder\**" />
-	  <MauiCss Remove="Services\ClearFields\**" />
-	  <MauiCss Remove="TestAutomation\**" />
-	  <MauiXaml Remove="NewFolder\**" />
-	  <MauiXaml Remove="Services\ClearFields\**" />
-	  <MauiXaml Remove="TestAutomation\**" />
-	  <None Remove="NewFolder\**" />
-	  <None Remove="Services\ClearFields\**" />
-	  <None Remove="TestAutomation\**" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <MauiImage Remove="Resources\Images\alemania.png" />
-	  <MauiImage Remove="Resources\Images\colombia.png" />
-	  <MauiImage Remove="Resources\Images\eeuu.png" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <None Remove="Resources\AppIcon\logoicono.svg" />
-	  <None Remove="Resources\Images\alemania.png" />
-	  <None Remove="Resources\Images\colombia.png" />
-	  <None Remove="Resources\Images\eeuu.png" />
-	  <None Remove="Resources\Splash\logosplash.svg" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Compile Update="Components\PopUp\Category.xaml.cs">
-	    <DependentUpon>Category.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="Components\PopUp\AddInfo.xaml.cs">
-	    <DependentUpon>AddInfo.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="Components\PopUp\OkBusiness.xaml.cs">
-	    <DependentUpon>OkBusiness.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="UsesCases\CompartimentCapacity\CompartimentCapacityPostView.xaml.cs">
-	    <DependentUpon>CompartimentCapacityPostView.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="UsesCases\EdsTank\EdsTankPostView.xaml.cs">
-	    <DependentUpon>EdsTankPostView.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="UsesCases\Expenditures\ExpendituresPostView.xaml.cs">
-	    <DependentUpon>ExpendituresPostView.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="UsesCases\HoseHistory\HoseHistoryPostView.xaml.cs">
-	    <DependentUpon>HoseHistoryPostView.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="UsesCases\Hose\HosePostView.xaml.cs">
-	    <DependentUpon>HosePostView.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="UsesCases\Island\IslandPostView.xaml.cs">
-	    <DependentUpon>IslandPostView.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="UsesCases\ProductCompartiment\ProductCompartimentPostView.xaml.cs">
-	    <DependentUpon>ProductCompartimentPostView.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="UsesCases\ProductType\ProductTypePostView.xaml.cs">
-	    <DependentUpon>ProductTypePostView.xaml</DependentUpon>
-	  </Compile>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Compile Update="UsesCases\Islander\IslanderPostView.xaml.cs">
-	    <DependentUpon>IslanderPostView.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="UsesCases\Tank\TankPostView.xaml.cs">
-	    <DependentUpon>TankPostView.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="UsesCases\TypeOfCollection\TypeOfCollectionPostView.xaml.cs">
-	    <DependentUpon>TypeOfCollectionPostView.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="UsesCases\Wizard\SetupWizardView.xaml.cs">
-	    <DependentUpon>SetupWizardView.xaml</DependentUpon>
-	  </Compile>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <MauiXaml Update="Components\PopUp\AddDispenser.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Components\PopUp\Category.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Components\PopUp\AddInfo.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Components\PopUp\CourtDetailPopup.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Components\PopUp\CustomAlert.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Components\PopUp\OkBusiness.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Custom\CustomEntry.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Custom\CustomEntryForm.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Custom\CustomEntryPin.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Styles\IconStyles.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Resources\Styles\Styles.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Business\BusinessListView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\CompartimentCapacity\CompartimentCapacityPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Court\CourtDetailPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Court\CourtListView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Island\IslandPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\LoadingView\LoadingView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Inventory\InventoryPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\LoadingView\LoadingView_Clean.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Phone\PhoneRegistrationView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\ProductCompartiment\ProductCompartimentPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\HoseHistory\HoseHistoryPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Eds\EdsPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Hose\HosePostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Capacity\CapacityPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Navigation\Main.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Provider\ProviderPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Shopping\ShoppingPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\StrongBox\StrongBoxView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Tank\TankPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\TypeOfCollection\TypeOfCollectionPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Expenditures\ExpendituresPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\ProductType\ProductTypePostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Business\BusinessPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Court\CourtPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Court\CourtView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Islander\IslanderPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Login\LoginPinView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Login\LoginView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Product\ProductPostView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="UsesCases\Wizard\SetupWizardView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	</ItemGroup>
-
+    <!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
+    <OutputType>Exe</OutputType>
+    <RootNamespace>APP.Eds</RootNamespace>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <!-- Display name -->
+    <ApplicationTitle>Poliedro</ApplicationTitle>
+    <!-- App Identifier -->
+    <ApplicationId>com.companyname.app.eds</ApplicationId>
+    <!-- Versions -->
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <ApplicationVersion>1</ApplicationVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0-windows10.0.19041.0'">
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishReadyToRun>False</PublishReadyToRun>
+  </PropertyGroup>
+  <!-- ANDROID: Configuración para API 35 -->
+  <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+    <AndroidMinSdkVersion>21</AndroidMinSdkVersion>
+    <AndroidTargetSdkVersion>35</AndroidTargetSdkVersion>
+    <AndroidCompileSdkVersion>35</AndroidCompileSdkVersion>
+    <TargetFrameworkVersion>v14.0</TargetFrameworkVersion>
+    <!-- Evita que el build "baje" al último conocido por VS -->
+    <UseLatestAndroidSdk>false</UseLatestAndroidSdk>
+    <!-- Asegurar que use la versión específica -->
+    <AndroidSdkDirectory Condition="'$(AndroidSdkDirectory)' == ''">$(ANDROID_HOME)</AndroidSdkDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-android|AnyCPU'">
+    <AndroidUseAapt2>True</AndroidUseAapt2>
+    <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
+    <AndroidPackageFormat>aab</AndroidPackageFormat>
+    <ApplicationVersion>7</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+    <ApplicationId>com.companyname.app.EDS</ApplicationId>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-android|AnyCPU'">
+    <AndroidPackageFormat>aab</AndroidPackageFormat>
+    <AndroidUseAapt2>True</AndroidUseAapt2>
+    <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
+    <ApplicationVersion>7</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+    <ApplicationId>com.companyname.app.EDS</ApplicationId>
+    <AndroidLinkTool>r8</AndroidLinkTool>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
+    <ApplicationVersion>7</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+    <ApplicationId>com.companyname.app.EDS</ApplicationId>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-maccatalyst|AnyCPU'">
+    <ApplicationVersion>7</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+    <ApplicationId>com.companyname.app.EDS</ApplicationId>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-windows10.0.19041.0|AnyCPU'">
+    <ApplicationVersion>7</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+    <ApplicationId>com.companyname.app.EDS</ApplicationId>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios|AnyCPU'">
+    <ApplicationVersion>7</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+    <ApplicationId>com.companyname.app.EDS</ApplicationId>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-maccatalyst|AnyCPU'">
+    <ApplicationVersion>7</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+    <ApplicationId>com.companyname.app.EDS</ApplicationId>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-windows10.0.19041.0|AnyCPU'">
+    <ApplicationVersion>7</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0.1</ApplicationDisplayVersion>
+    <ApplicationId>com.companyname.app.EDS</ApplicationId>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- App Icon -->
+    <MauiIcon Include="Resources\AppIcon\logoicono.svg" />
+    <!-- Splash Screen -->
+    <MauiSplashScreen Include="Resources\Splash\logosplash.svg" Color="#FFFFFF" BaseSize="512,512" />
+    <!-- Images -->
+    <MauiImage Include="Resources\Images\*" />
+    <MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185" />
+    <!-- Custom Fonts -->
+    <MauiFont Include="Resources\Fonts\*" />
+    <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
+    <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Remove="NewFolder\**" />
+    <AndroidResource Remove="Services\ClearFields\**" />
+    <AndroidResource Remove="TestAutomation\**" />
+    <Compile Remove="NewFolder\**" />
+    <Compile Remove="Services\ClearFields\**" />
+    <Compile Remove="TestAutomation\**" />
+    <EmbeddedResource Remove="NewFolder\**" />
+    <EmbeddedResource Remove="Services\ClearFields\**" />
+    <EmbeddedResource Remove="TestAutomation\**" />
+    <MauiCss Remove="NewFolder\**" />
+    <MauiCss Remove="Services\ClearFields\**" />
+    <MauiCss Remove="TestAutomation\**" />
+    <MauiXaml Remove="NewFolder\**" />
+    <MauiXaml Remove="Services\ClearFields\**" />
+    <MauiXaml Remove="TestAutomation\**" />
+    <None Remove="NewFolder\**" />
+    <None Remove="Services\ClearFields\**" />
+    <None Remove="TestAutomation\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <MauiImage Remove="Resources\Images\alemania.png" />
+    <MauiImage Remove="Resources\Images\colombia.png" />
+    <MauiImage Remove="Resources\Images\eeuu.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Resources\AppIcon\logoicono.svg" />
+    <None Remove="Resources\Images\alemania.png" />
+    <None Remove="Resources\Images\colombia.png" />
+    <None Remove="Resources\Images\eeuu.png" />
+    <None Remove="Resources\Splash\logosplash.svg" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Components\PopUp\Category.xaml.cs">
+      <DependentUpon>Category.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Components\PopUp\AddInfo.xaml.cs">
+      <DependentUpon>AddInfo.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Components\PopUp\OkBusiness.xaml.cs">
+      <DependentUpon>OkBusiness.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="UsesCases\CompartimentCapacity\CompartimentCapacityPostView.xaml.cs">
+      <DependentUpon>CompartimentCapacityPostView.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="UsesCases\EdsTank\EdsTankPostView.xaml.cs">
+      <DependentUpon>EdsTankPostView.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="UsesCases\Expenditures\ExpendituresPostView.xaml.cs">
+      <DependentUpon>ExpendituresPostView.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="UsesCases\HoseHistory\HoseHistoryPostView.xaml.cs">
+      <DependentUpon>HoseHistoryPostView.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="UsesCases\Hose\HosePostView.xaml.cs">
+      <DependentUpon>HosePostView.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="UsesCases\Island\IslandPostView.xaml.cs">
+      <DependentUpon>IslandPostView.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="UsesCases\ProductCompartiment\ProductCompartimentPostView.xaml.cs">
+      <DependentUpon>ProductCompartimentPostView.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="UsesCases\ProductType\ProductTypePostView.xaml.cs">
+      <DependentUpon>ProductTypePostView.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="UsesCases\Islander\IslanderPostView.xaml.cs">
+      <DependentUpon>IslanderPostView.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="UsesCases\Tank\TankPostView.xaml.cs">
+      <DependentUpon>TankPostView.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="UsesCases\TypeOfCollection\TypeOfCollectionPostView.xaml.cs">
+      <DependentUpon>TypeOfCollectionPostView.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="UsesCases\Wizard\SetupWizardView.xaml.cs">
+      <DependentUpon>SetupWizardView.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <MauiXaml Update="Components\PopUp\AddDispenser.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="Components\PopUp\Category.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="Components\PopUp\AddInfo.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="Components\PopUp\CourtDetailPopup.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="Components\PopUp\CustomAlert.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="Components\PopUp\OkBusiness.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="Resources\Custom\CustomEntry.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="Resources\Custom\CustomEntryForm.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="Resources\Custom\CustomEntryPin.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="Resources\Styles\IconStyles.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="Resources\Styles\Styles.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Business\BusinessListView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\CompartimentCapacity\CompartimentCapacityPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Court\CourtDetailPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Court\CourtListView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Island\IslandPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\LoadingView\LoadingView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Inventory\InventoryPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\LoadingView\LoadingView_Clean.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Phone\PhoneRegistrationView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\ProductCompartiment\ProductCompartimentPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\HoseHistory\HoseHistoryPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Eds\EdsPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Hose\HosePostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Capacity\CapacityPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Navigation\Main.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Provider\ProviderPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Shopping\ShoppingPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\StrongBox\StrongBoxView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Tank\TankPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\TypeOfCollection\TypeOfCollectionPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Expenditures\ExpendituresPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\ProductType\ProductTypePostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Business\BusinessPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Court\CourtPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Court\CourtView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Islander\IslanderPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Login\LoginPinView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Login\LoginView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Product\ProductPostView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+    <MauiXaml Update="UsesCases\Wizard\SetupWizardView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </MauiXaml>
+  </ItemGroup>
 </Project>

--- a/APP.Eds/Helpers/Helpers.csproj
+++ b/APP.Eds/Helpers/Helpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/APP.Eds/Helpers/Helpers.csproj
+++ b/APP.Eds/Helpers/Helpers.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.10" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.10" />
     <PackageReference Include="NUnit" Version="4.2.2" />
   </ItemGroup>
 

--- a/APP.Eds/Mobile_tests/Mobile_tests.csproj
+++ b/APP.Eds/Mobile_tests/Mobile_tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/APP.Eds/Mobile_tests/Mobile_tests.csproj
+++ b/APP.Eds/Mobile_tests/Mobile_tests.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.15" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.4.0" />

--- a/APP.Eds/Mobile_views/Mobile_views.csproj
+++ b/APP.Eds/Mobile_views/Mobile_views.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/APP.Eds/Mobile_views/Mobile_views.csproj
+++ b/APP.Eds/Mobile_views/Mobile_views.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="8.0.15" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary by Sourcery

Upgrade projects to target .NET 9, update related NuGet dependencies, and add an upgrade plan document

Enhancements:
- Update project target frameworks from .NET 8 to .NET 9 across Helpers, Mobile_views, Mobile_tests, and Poliedro (including multi-target frameworks for Poliedro)
- Bump relevant NuGet packages (Microsoft.Extensions.Configuration.Json, Microsoft.Extensions.Logging.Debug, Microsoft.NET.ILLink.Tasks, Newtonsoft.Json) to .NET 9–compatible versions

Documentation:
- Add .NET 9 upgrade plan in .github/upgrades for step-by-step guidance and dependency update details