### PR TITLE
Poliedro

### DIFF
--- a/.github/workflows/CI build.yml
+++ b/.github/workflows/CI build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup .NET 8
+      - name: Setup .NET 9
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: 9.0.x

--- a/.github/workflows/CI build.yml
+++ b/.github/workflows/CI build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Cache .NET dependencies (General)
         uses: actions/cache@v3


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Bump setup-dotnet step to use .NET SDK 9.0.x and rename the step accordingly