### PR TITLE
Update CI workflow to use Poliedro project

### DIFF
--- a/.github/workflows/CI build.yml
+++ b/.github/workflows/CI build.yml
@@ -48,13 +48,13 @@ jobs:
         run: dotnet workload install maui --ignore-failed-sources
 
       - name: Restore Dependencies
-        run: dotnet restore APP.Eds/APP.Eds/APP.Eds.csproj --runtime win-x64
+        run: dotnet restore APP.Eds/APP.Eds/Poliedro.csproj --runtime win-x64
 
       - name: Build
-        run: dotnet build APP.Eds/APP.Eds/APP.Eds.csproj --no-restore -c Release -f net8.0-windows10.0.19041.0 -r win-x64
+        run: dotnet build APP.Eds/APP.Eds/Poliedro.csproj --no-restore -c Release -f net8.0-windows10.0.19041.0 -r win-x64
 
       - name: Run Unit Tests
-        run: dotnet test APP.Eds/APP.Eds.sln --no-build --verbosity normal
+        run: dotnet test APP.Eds/Poliedro.sln --no-build --verbosity normal
 
   sonar:
     needs: build-and-test


### PR DESCRIPTION
## Summary by Sourcery

Update the CI build workflow to target the new Poliedro project

CI:
- Restore step now references Poliedro.csproj instead of APP.Eds.csproj
- Build step now compiles Poliedro.csproj instead of APP.Eds.csproj
- Test step now runs against Poliedro.sln instead of APP.Eds.sln